### PR TITLE
fix: Use layout defaultChronicleLocation as authoritative blank chronicle path

### DIFF
--- a/scripts/PartyChronicleApp.ts
+++ b/scripts/PartyChronicleApp.ts
@@ -126,17 +126,26 @@ export class PartyChronicleApp extends HandlebarsApplicationMixin(ApplicationV2)
       const shared = this.mapPartyFieldsToContext(savedData, effectiveLayoutId, selectedSeasonId);
 
       // Check if chronicle path file exists and if layout has a default location
-      const chroniclePath = savedData?.shared?.blankChroniclePath || '';
+      let layoutDefaultChronicleLocation: string | undefined;
+      if (effectiveLayoutId) {
+        const selectedLayout = await layoutStore.getLayout(effectiveLayoutId);
+        layoutDefaultChronicleLocation = selectedLayout?.defaultChronicleLocation;
+      }
+
+      // When the layout has a default chronicle location, use it as the authoritative
+      // blank chronicle path. This ensures the correct game system's chronicle PDF is
+      // used (e.g., Starfinder layout always uses the Starfinder chronicle, even if
+      // saved data still references a Pathfinder chronicle from a previous session).
+      if (layoutDefaultChronicleLocation) {
+        shared.blankChroniclePath = layoutDefaultChronicleLocation;
+      }
+
+      const chroniclePath = shared.blankChroniclePath || '';
       debug(`_prepareContext: chroniclePath = "${chroniclePath}"`);
       const chroniclePathExists = await this.checkFileExists(chroniclePath);
       debug(`_prepareContext: chroniclePathExists = ${chroniclePathExists}`);
       
-      // Get the selected layout to check if it has a default chronicle location
-      let layoutHasDefault = false;
-      if (effectiveLayoutId) {
-        const selectedLayout = await layoutStore.getLayout(effectiveLayoutId);
-        layoutHasDefault = !!selectedLayout?.defaultChronicleLocation;
-      }
+      const layoutHasDefault = !!layoutDefaultChronicleLocation;
       debug(`_prepareContext: layoutHasDefault = ${layoutHasDefault}`);
       
       // Field should be hidden only if:

--- a/scripts/handlers/chronicle-generation.ts
+++ b/scripts/handlers/chronicle-generation.ts
@@ -102,8 +102,13 @@ async function loadLayoutConfiguration(
     return null;
   }
   
-  // Get the blank chronicle path
-  const blankChroniclePath = data.shared?.blankChroniclePath || game.settings.get('pfs-chronicle-generator', 'blankChroniclePath');
+  // Get the blank chronicle path, preferring the layout's default when available.
+  // The layout's defaultChronicleLocation is the authoritative source for which
+  // blank PDF to use — it ensures the correct game system's chronicle is loaded
+  // (e.g., Starfinder layout uses Starfinder chronicle, not a stale Pathfinder path).
+  const blankChroniclePath = layout.defaultChronicleLocation
+    || data.shared?.blankChroniclePath
+    || game.settings.get('pfs-chronicle-generator', 'blankChroniclePath');
   
   if (!blankChroniclePath || typeof blankChroniclePath !== 'string') {
     ui.notifications?.error("Blank chronicle PDF path is not set.");


### PR DESCRIPTION
When Starfinder is active via sf2e-anachronism module, the correct Starfinder layout was selected but the blank chronicle PDF path still pointed to the previously-used Pathfinder chronicle. The layout's defaultChronicleLocation is now the first-priority source at both render time and generation time, ensuring the correct game system's chronicle PDF is always used.