### PR TITLE
feat: Add GM override controls for XP and currency

### DIFF
--- a/.kiro/specs/gm-override-values/.config.kiro
+++ b/.kiro/specs/gm-override-values/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "c20e4423-0724-41da-8614-13a2f242063c", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/gm-override-values/design.md
+++ b/.kiro/specs/gm-override-values/design.md
@@ -1,0 +1,456 @@
+# Design Document: GM Override Values
+
+## Overview
+
+The PFS Chronicle Generator automatically calculates `xp_gained` and `currency_gained` for each character based on shared reward settings and per-character earned income inputs. However, feats, boons, and certain downtime activities can modify these values in ways the calculator cannot account for. This feature adds an "Advanced" collapsible section to each character card that allows the GM to override the calculated XP and currency values with explicit numeric inputs.
+
+The design introduces override checkboxes and numeric inputs within a new collapsible "Advanced" section on each character card (both party members and GM credit character). The existing "Consume Replay" checkbox relocates into this section to reduce default-view clutter. When an override checkbox is checked, the corresponding calculated label receives strikethrough styling, and the override value replaces the calculated value in both chronicle PDF generation and session reporting. Override data persists through the existing auto-save pipeline and restores on reload.
+
+The design follows the existing hybrid ApplicationV2 pattern: context preparation in `PartyChronicleApp._prepareContext()`, template rendering via Handlebars, and event listener attachment in `main.ts`. The collapsible section reuses the existing `Collapsible_Section_Handler` infrastructure.
+
+## Architecture
+
+The override feature integrates into the existing architecture by extending the per-character data model and inserting override-aware logic into the chronicle generation and session report pipelines. No new top-level modules are introduced. Changes are distributed across the existing layers:
+
+```mermaid
+graph TD
+    subgraph "Data Model"
+        UF["UniqueFields"]
+        UF -->|new fields| OXP["overrideXp: boolean"]
+        UF -->|new fields| OXPV["overrideXpValue: number"]
+        UF -->|new fields| OC["overrideCurrency: boolean"]
+        UF -->|new fields| OCV["overrideCurrencyValue: number"]
+    end
+
+    subgraph "Template & UI"
+        HBS["party-chronicle-filling.hbs"]
+        HBS -->|render per character| ADV["Advanced Section<br/>(collapsible, collapsed by default)"]
+        ADV -->|contains| CR["Consume Replay checkbox<br/>(relocated)"]
+        ADV -->|contains| OXCB["Override XP checkbox + input"]
+        ADV -->|contains| OCCB["Override Currency checkbox + input"]
+    end
+```
+```mermaid
+graph TD
+    subgraph "Event Handling"
+        MAIN["main.ts"]
+        MAIN -->|attach| OH["override-handlers.ts"]
+        OH -->|toggle| DIS["Input disabled state"]
+        OH -->|toggle| ST["Strikethrough CSS class"]
+        OH -->|trigger| AS["Auto-save via handleFieldChange"]
+    end
+
+    subgraph "Chronicle Generation"
+        MAP["party-chronicle-mapper.ts"]
+        MAP -->|check overrideXp| XPD{"overrideXp?"}
+        XPD -->|yes| OXPV2["use overrideXpValue"]
+        XPD -->|no| CALC["use shared.xpEarned"]
+        MAP -->|check overrideCurrency| CD{"overrideCurrency?"}
+        CD -->|yes| OCV2["use overrideCurrencyValue"]
+        CD -->|no| CALC2["calculate currency_gained"]
+    end
+```
+```mermaid
+graph TD
+    subgraph "Session Reporting"
+        SRB["session-report-builder.ts"]
+        SRB -->|check overrides| SR["Use override values<br/>when active"]
+    end
+
+    subgraph "Persistence"
+        FDE["form-data-extraction.ts"]
+        FDE -->|extract override fields| STORE["party-chronicle-storage.ts"]
+        STORE -->|save to| WS["Foundry world settings"]
+    end
+```
+
+### Key Architectural Decisions
+
+1. **Override fields stored in `UniqueFields`, not `SharedFields`.** Overrides are per-character, so they belong in the character-specific data structure. This keeps the data model consistent — each character's overrides are stored alongside their other unique fields under `characters[actorId]`.
+
+2. **Reuse existing `Collapsible_Section_Handler` for the Advanced section.** The Advanced section is registered as a new collapsible section ID (`advanced-{characterId}`) in the collapsible section handler infrastructure. This provides toggle, keyboard support, ARIA attributes, and collapse state persistence for free. Because each character card has its own Advanced section, the section ID includes the character ID to keep collapse states independent.
+
+3. **Override handler as a new dedicated module.** A new `handlers/override-handlers.ts` module encapsulates the checkbox toggle logic (enable/disable input, apply/remove strikethrough). This keeps the handler logic testable and avoids bloating existing handler files.
+
+4. **Override-aware mapping in `mapToCharacterData`.** The existing mapper function is extended to accept override fields and conditionally use override values instead of calculated values. This is the single point where the override decision is made for chronicle generation, keeping the logic centralized.
+
+5. **Consume Replay relocation is a template-only change.** Moving the Consume Replay checkbox into the Advanced section requires no logic changes — the `name` attribute, form data extraction, and auto-save all work identically regardless of DOM position.
+
+6. **Strikethrough applied via CSS class, not inline styles.** A `.strikethrough-override` CSS class is added to the stylesheet. The override handler toggles this class on the calculated label elements. This keeps styling concerns in CSS and behavior in JavaScript.
+
+## Components and Interfaces
+
+### Modified Interfaces
+
+#### `UniqueFields` (party-chronicle-types.ts)
+
+Add override fields:
+
+```typescript
+export interface UniqueFields {
+  // ... existing fields ...
+
+  /** Whether the XP override is active for this character */
+  overrideXp: boolean;
+
+  /** Override XP value (used when overrideXp is true) */
+  overrideXpValue: number;
+
+  /** Whether the currency override is active for this character */
+  overrideCurrency: boolean;
+
+  /** Override currency value (used when overrideCurrency is true) */
+  overrideCurrencyValue: number;
+}
+```
+
+### New Module: `handlers/override-handlers.ts`
+
+```typescript
+/**
+ * Handles override checkbox change events.
+ * Toggles the associated input's disabled state and applies/removes
+ * strikethrough styling on the calculated labels.
+ */
+export function handleOverrideXpChange(
+  characterId: string,
+  container: HTMLElement
+): void;
+
+export function handleOverrideCurrencyChange(
+  characterId: string,
+  container: HTMLElement
+): void;
+
+/**
+ * Initializes override states from saved data on form load.
+ * For each character, reads the override checkbox states and applies
+ * the correct disabled/enabled and strikethrough states.
+ */
+export function initializeOverrideStates(container: HTMLElement): void;
+```
+
+### Modified Functions
+
+#### `mapToCharacterData()` (party-chronicle-mapper.ts)
+
+Extended to check `overrideXp` and `overrideCurrency` flags on `UniqueFields`:
+
+- When `overrideXp === true`: set `xp_gained = overrideXpValue` instead of `shared.xpEarned`
+- When `overrideCurrency === true`: set `currency_gained = overrideCurrencyValue` instead of the calculated `treasureBundleValue + earnedIncome`
+
+#### `extractFormData()` (form-data-extraction.ts)
+
+Extended to read the four new override fields per character from the DOM:
+
+- `overrideXp`: checkbox checked state from `input[name="characters.{id}.overrideXp"]`
+- `overrideXpValue`: numeric value from `input[name="characters.{id}.overrideXpValue"]`
+- `overrideCurrency`: checkbox checked state from `input[name="characters.{id}.overrideCurrency"]`
+- `overrideCurrencyValue`: numeric value from `input[name="characters.{id}.overrideCurrencyValue"]`
+
+#### `buildSessionReport()` (session-report-builder.ts)
+
+The `buildSignUp` and `buildGmSignUp` functions are extended to accept override fields. When overrides are active, the session report uses override values for XP and currency instead of the shared/calculated values.
+
+#### `buildDefaultCharacterFields()` (event-listener-helpers.ts)
+
+Extended to include default override fields in the clear-data defaults:
+
+```typescript
+overrideXp: false,
+overrideXpValue: 0,
+overrideCurrency: false,
+overrideCurrencyValue: 0,
+```
+
+#### `initializeCollapseSections()` (collapsible-section-handlers.ts)
+
+The `VALID_SECTION_IDS` array is extended to support dynamic per-character Advanced section IDs. The initialization loop is updated to handle sections with IDs matching the `advanced-{characterId}` pattern.
+
+#### `attachEventListeners()` (main.ts)
+
+Extended to attach override checkbox change listeners and call `initializeOverrideStates()` during form initialization.
+
+### DOM Selectors (dom-selectors.ts)
+
+```typescript
+export const CHARACTER_FIELD_SELECTORS = {
+  // ... existing selectors ...
+  OVERRIDE_XP: (characterId: string) => `input[name="characters.${characterId}.overrideXp"]`,
+  OVERRIDE_XP_VALUE: (characterId: string) => `input[name="characters.${characterId}.overrideXpValue"]`,
+  OVERRIDE_CURRENCY: (characterId: string) => `input[name="characters.${characterId}.overrideCurrency"]`,
+  OVERRIDE_CURRENCY_VALUE: (characterId: string) => `input[name="characters.${characterId}.overrideCurrencyValue"]`,
+  CALCULATED_XP_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .calculated-xp-label`,
+  CALCULATED_CURRENCY_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .calculated-currency-label`,
+  EARNED_INCOME_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .earned-income-label`,
+} as const;
+
+export const CHARACTER_FIELD_PATTERNS = {
+  // ... existing patterns ...
+  OVERRIDE_XP_ALL: 'input[name$=".overrideXp"]',
+  OVERRIDE_CURRENCY_ALL: 'input[name$=".overrideCurrency"]',
+} as const;
+```
+
+### CSS Classes
+
+```typescript
+export const CSS_CLASSES = {
+  // ... existing classes ...
+  STRIKETHROUGH_OVERRIDE: 'strikethrough-override',
+} as const;
+```
+
+### Template Changes (party-chronicle-filling.hbs)
+
+Each character card (both party member `{{#each partyMembers}}` loop and GM character section) gains an Advanced collapsible section. The Consume Replay checkbox moves from its current position into this section. The Advanced section structure:
+
+```handlebars
+<div class="collapsible-section advanced-section" data-section-id="advanced-{{this.id}}">
+  <header class="collapsible-header" role="button" tabindex="0"
+          aria-expanded="false" aria-controls="advanced-content-{{this.id}}">
+    <span class="chevron"></span>
+    <span class="section-title">Advanced</span>
+  </header>
+  <div class="collapsible-content" id="advanced-content-{{this.id}}">
+    {{!-- Consume Replay (relocated) --}}
+    <div class="form-group">
+      <label class="checkbox-label" data-tooltip="...existing tooltip...">
+        <input type="checkbox" name="characters.{{this.id}}.consumeReplay" ...>
+        Consume Replay
+      </label>
+    </div>
+
+    {{!-- Override XP --}}
+    <div class="form-group override-group">
+      <label class="checkbox-label">
+        <input type="checkbox" name="characters.{{this.id}}.overrideXp" ...>
+        Override XP
+      </label>
+      <input type="number" name="characters.{{this.id}}.overrideXpValue"
+             min="0" step="1" disabled ...>
+    </div>
+
+    {{!-- Override Currency (system-aware label) --}}
+    <div class="form-group override-group">
+      <label class="checkbox-label">
+        <input type="checkbox" name="characters.{{this.id}}.overrideCurrency" ...>
+        {{#if (eq ../gameSystem "sf2e")}}Override Credits Gained{{else}}Override GP Gained{{/if}}
+      </label>
+      <input type="number" name="characters.{{this.id}}.overrideCurrencyValue"
+             min="0" {{#if (eq ../gameSystem "sf2e")}}step="1"{{else}}step="0.01"{{/if}} disabled ...>
+    </div>
+  </div>
+</div>
+```
+
+The existing calculated XP and currency display elements gain CSS classes for targeting by the strikethrough handler:
+
+- XP display: add class `calculated-xp-label`
+- Currency display (treasure bundle value / credits awarded): add class `calculated-currency-label`
+- Earned Income label: add class `earned-income-label`
+
+## Data Models
+
+### Persistence Structure
+
+Override data is stored within the existing `PartyChronicleData` structure. No new storage keys or mechanisms are needed:
+
+```typescript
+// Stored in game.settings under 'pfs-chronicle-generator.partyChronicleData'
+{
+  timestamp: 1234567890,
+  data: {
+    shared: {
+      // ... existing shared fields (unchanged) ...
+    },
+    characters: {
+      "actor-id-1": {
+        // ... existing UniqueFields ...
+        overrideXp: true,
+        overrideXpValue: 2,
+        overrideCurrency: false,
+        overrideCurrencyValue: 0
+      },
+      "actor-id-2": {
+        // ... existing UniqueFields ...
+        overrideXp: false,
+        overrideXpValue: 0,
+        overrideCurrency: true,
+        overrideCurrencyValue: 150.5
+      }
+    }
+  }
+}
+```
+
+### Override Decision Flow in Chronicle Generation
+
+```mermaid
+flowchart TD
+    START["mapToCharacterData(shared, unique, actor)"] --> CHECK_XP{"unique.overrideXp?"}
+    CHECK_XP -->|true| USE_OXP["xp_gained = unique.overrideXpValue"]
+    CHECK_XP -->|false| USE_CALC_XP["xp_gained = shared.xpEarned"]
+
+    USE_OXP --> CHECK_CUR{"unique.overrideCurrency?"}
+    USE_CALC_XP --> CHECK_CUR
+
+    CHECK_CUR -->|true| USE_OC["currency_gained = unique.overrideCurrencyValue"]
+    CHECK_CUR -->|false| USE_CALC_CUR["currency_gained = treasureBundleValue + earnedIncome"]
+
+    USE_OC --> RESULT["Return ChronicleData"]
+    USE_CALC_CUR --> RESULT
+```
+
+### Override Checkbox Interaction Flow
+
+```mermaid
+sequenceDiagram
+    actor GM
+    participant CB as Override Checkbox
+    participant INP as Override Input
+    participant LBL as Calculated Label
+    participant EIL as Earned Income Label
+    participant SAVE as Auto-save
+
+    GM->>CB: Check override
+    CB->>INP: Remove disabled attribute
+    CB->>LBL: Add .strikethrough-override class
+    Note over EIL: Currency override only
+    CB->>EIL: Add .strikethrough-override class
+    CB->>SAVE: Trigger auto-save
+
+    GM->>INP: Enter override value
+    INP->>SAVE: Trigger auto-save
+
+    GM->>CB: Uncheck override
+    CB->>INP: Add disabled attribute
+    CB->>LBL: Remove .strikethrough-override class
+    CB->>EIL: Remove .strikethrough-override class
+    CB->>SAVE: Trigger auto-save
+```
+
+### Collapsible Section Registration
+
+The Advanced section uses per-character section IDs to maintain independent collapse states:
+
+| Section ID Pattern | Default State | Has Summary |
+|---|---|---|
+| `advanced-{characterId}` | Collapsed | No |
+
+The collapsible section handler's `isValidSectionId()` function is updated to accept IDs matching the `advanced-` prefix pattern, in addition to the existing static section IDs.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: XP override checkbox controls input state and strikethrough
+
+*For any* character card and any override XP checkbox state (checked or unchecked), the Override_XP_Input disabled attribute should be the inverse of the checkbox checked state, and the Calculated_XP_Label should have the `strikethrough-override` CSS class if and only if the checkbox is checked.
+
+**Validates: Requirements 3.3, 3.4, 3.5, 3.6**
+
+### Property 2: Currency override checkbox controls input state and strikethrough
+
+*For any* character card and any override currency checkbox state (checked or unchecked), the Override_Currency_Input disabled attribute should be the inverse of the checkbox checked state, and both the Calculated_Currency_Label and the Earned_Income_Label should have the `strikethrough-override` CSS class if and only if the checkbox is checked.
+
+**Validates: Requirements 4.5, 4.6, 4.7, 4.8**
+
+### Property 3: XP override in chronicle generation
+
+*For any* valid `SharedFields` with `xpEarned` and any valid `UniqueFields` with `overrideXp` and `overrideXpValue`, when `overrideXp` is true, `mapToCharacterData` should produce a `ChronicleData` with `xp_gained` equal to `overrideXpValue`; when `overrideXp` is false, `xp_gained` should equal `shared.xpEarned`.
+
+**Validates: Requirements 5.1, 5.3**
+
+### Property 4: Currency override in chronicle generation
+
+*For any* valid `SharedFields` and any valid `UniqueFields` with `overrideCurrency` and `overrideCurrencyValue`, when `overrideCurrency` is true, `mapToCharacterData` should produce a `ChronicleData` with `currency_gained` equal to `overrideCurrencyValue`; when `overrideCurrency` is false, `currency_gained` should equal the standard calculated value (treasure bundle value + earned income).
+
+**Validates: Requirements 5.2, 5.4**
+
+### Property 5: Override data persistence round-trip
+
+*For any* valid set of override field values (`overrideXp`, `overrideXpValue`, `overrideCurrency`, `overrideCurrencyValue`), saving a `PartyChronicleData` structure containing those values and then loading it should produce identical override field values for each character.
+
+**Validates: Requirements 6.1, 6.2**
+
+### Property 6: Clear resets all overrides
+
+*For any* `PartyChronicleData` structure with any combination of override states and values across any number of characters, after applying the clear-data defaults, every character's `overrideXp` and `overrideCurrency` should be `false`, and `overrideXpValue` and `overrideCurrencyValue` should be `0`.
+
+**Validates: Requirements 6.3**
+
+### Property 7: Override values in session report
+
+*For any* character with override fields, when `overrideXp` is true the session report should use `overrideXpValue` as the XP for that character, and when `overrideCurrency` is true the session report should use `overrideCurrencyValue` as the currency for that character. When overrides are not active, the standard calculated values should be used.
+
+**Validates: Requirements 7.1, 7.2, 7.3**
+
+### Property 8: Per-character override independence
+
+*For any* two distinct characters in the same form, changing one character's override checkbox or value should not modify the other character's override state or value. Each character's override fields in the extracted form data should be independent.
+
+**Validates: Requirements 8.1, 8.2, 8.3**
+
+## Error Handling
+
+| Scenario | Handling |
+|---|---|
+| Override input contains non-numeric value | HTML `type="number"` prevents non-numeric entry. If a non-numeric value somehow reaches extraction, `Number.parseFloat()` returns `NaN` which falls back to `0`. |
+| Override input is empty when checkbox is checked | Treat as `0`. The override value of `0` is explicitly valid per requirements (Req 5.1, 5.2). |
+| Override input has negative value | The `min="0"` attribute on the input prevents negative values in the UI. If a negative value reaches extraction, it is used as-is — the GM may have a legitimate reason (though unusual). |
+| Saved data missing override fields (migration) | When loading saved data that predates this feature, the override fields will be `undefined`. The form data extraction uses `|| false` for checkboxes and `|| 0` for numeric values, providing safe defaults. No migration script needed. |
+| Collapsible section ID not found for Advanced section | The collapsible section handler's `isValidSectionId()` is updated to accept `advanced-*` patterns. If a section element is missing from the DOM (e.g., character removed), the handler silently skips it per existing behavior. |
+| Override checkbox change fails to auto-save | Handled by existing `saveFormData()` error handling: logs error, shows `ui.notifications.warn()`. Override state in the DOM remains correct even if persistence fails. |
+| Currency override value exceeds step precision | HTML `step` attribute provides UI guidance but does not enforce server-side. The value is stored as-is. For Pathfinder, `step="0.01"` guides 2 decimal places; for Starfinder, `step="1"` guides whole numbers. |
+
+## Testing Strategy
+
+### Property-Based Tests
+
+Property-based tests use `fast-check` (already available in the project). Each property test runs a minimum of 100 iterations.
+
+Tests target the pure logic functions that can be exercised without Foundry runtime:
+
+- **Override checkbox toggle logic** (Properties 1, 2): Test `handleOverrideXpChange` and `handleOverrideCurrencyChange` with generated character IDs and checkbox states against a mock DOM, verifying disabled attributes and CSS classes.
+- **Chronicle generation mapping** (Properties 3, 4): Test `mapToCharacterData` with generated `SharedFields` and `UniqueFields` containing random override states and values, verifying `xp_gained` and `currency_gained` in the output.
+- **Persistence round-trip** (Property 5): Test save/load cycle with generated `UniqueFields` containing random override values using a mock storage.
+- **Clear resets overrides** (Property 6): Test `buildDefaultCharacterFields` with generated party actors, verifying all override fields are reset to defaults.
+- **Session report overrides** (Property 7): Test `buildSessionReport` with generated override values, verifying the report uses override values when active and calculated values when not.
+- **Per-character independence** (Property 8): Test `extractFormData` with generated multi-character forms, verifying that each character's override fields are independent.
+
+Configuration:
+- Library: `fast-check`
+- Minimum iterations: 100 per property
+- Tag format: `Feature: gm-override-values, Property {N}: {title}`
+
+### Unit Tests (Example-Based)
+
+Unit tests cover specific examples, UI rendering verification, and edge cases:
+
+- Advanced section renders within each character card (Req 1.1)
+- Advanced section has title "Advanced" (Req 1.2)
+- Advanced section is collapsed by default (Req 1.3)
+- Advanced section supports keyboard activation (Req 1.5)
+- Advanced section has correct ARIA attributes (Req 1.6)
+- Consume Replay checkbox is inside Advanced section (Req 2.1)
+- Consume Replay retains name attribute format after relocation (Req 2.2)
+- Override XP checkbox and input render correctly (Req 3.1, 3.2)
+- Override XP input accepts numeric values (Req 3.7)
+- Override Currency checkbox label is "Override GP Gained" for Pathfinder (Req 4.2)
+- Override Currency checkbox label is "Override Credits Gained" for Starfinder (Req 4.3)
+- Override Currency input step is 0.01 for Pathfinder, 1 for Starfinder (Req 4.9)
+- GM character card has same override controls as party member cards (Req 8.4)
+- Override value of zero is used (not treated as "no override") (Req 5.1, 5.2)
+- Saved data without override fields loads with safe defaults (migration edge case)
+
+### Integration Tests
+
+Integration tests verify end-to-end workflows with mocked Foundry APIs:
+
+- Form data extraction includes override fields for all characters
+- Auto-save triggers on override checkbox and input changes
+- Chronicle generation uses override values when active
+- Session report uses override values when active
+- Clear Data button resets all override states
+- Form reload restores override states, input values, disabled states, and strikethrough styling

--- a/.kiro/specs/gm-override-values/requirements.md
+++ b/.kiro/specs/gm-override-values/requirements.md
@@ -1,0 +1,120 @@
+# Requirements Document
+
+## Introduction
+
+The PFS Chronicle Generator automatically calculates `xp_gained` and `currency_gained` for each character based on shared reward settings (XP earned, treasure bundles, downtime days) and per-character earned income inputs (task level, success level, proficiency rank). However, feats, boons, and certain downtime activities can modify these values in ways the calculator cannot account for. This feature adds an "Advanced" collapsible section to each character card (both party members and the GM credit character) that allows the GM to override the calculated XP and currency values. The existing "Consume Replay" checkbox relocates into this new section. Override checkboxes control whether the override is active, and when active, the calculated label outside the Advanced section receives strikethrough styling while the override input value replaces the calculated value during chronicle generation.
+
+## Glossary
+
+- **Society_Tab**: The GM-only tab injected into the Party Sheet by the module, containing the chronicle generation form.
+- **Character_Card**: A per-character section in the Society_Tab displaying character info and data entry fields. Applies to both Party_Actor sections and the GM_Character section.
+- **Advanced_Section**: A collapsible section within each Character_Card titled "Advanced" that contains override controls and the relocated Consume Replay checkbox.
+- **Override_XP_Checkbox**: A checkbox within the Advanced_Section that enables or disables the XP override for a specific character.
+- **Override_Currency_Checkbox**: A checkbox within the Advanced_Section that enables or disables the currency override for a specific character. Labeled "Override GP Gained" for Pathfinder and "Override Credits Gained" for Starfinder.
+- **Override_XP_Input**: A numeric input field next to the Override_XP_Checkbox where the GM enters the override XP value.
+- **Override_Currency_Input**: A numeric input field next to the Override_Currency_Checkbox where the GM enters the override currency value.
+- **Calculated_XP_Label**: The existing display element on the Character_Card that shows the XP earned value (from shared fields).
+- **Calculated_Currency_Label**: The existing display element on the Character_Card that shows the calculated currency gained value (earned income + treasure bundle value or credits awarded).
+- **Earned_Income_Label**: The existing "Earned Income" label on the Character_Card that titles the earned income display value, located within the earned income section.
+- **Chronicle_Generator**: The module's PDF generation pipeline that produces filled chronicle sheets for each character.
+- **Party_Actor**: A character actor that is a member of the Foundry VTT party.
+- **GM_Character**: The actor designated as the GM's character for GM credit.
+- **Collapsible_Section_Handler**: The existing module component that manages collapsible section toggle, keyboard support, and collapse state persistence.
+
+## Requirements
+
+### Requirement 1: Advanced Section Structure
+
+**User Story:** As a GM, I want each character card to have a collapsible "Advanced" section, so that override controls are available but do not clutter the default view.
+
+#### Acceptance Criteria
+
+1. THE Society_Tab SHALL display an Advanced_Section within each Character_Card, including both Party_Actor and GM_Character cards
+2. THE Advanced_Section SHALL have the title "Advanced"
+3. THE Advanced_Section SHALL be collapsed by default when the form is first rendered
+4. WHEN the GM clicks or activates the Advanced_Section header, THE Collapsible_Section_Handler SHALL toggle the section between collapsed and expanded states
+5. THE Advanced_Section SHALL support keyboard activation (Enter and Space keys) consistent with existing collapsible sections
+6. THE Advanced_Section SHALL use ARIA attributes (`aria-expanded`, `aria-controls`) consistent with existing collapsible sections
+
+### Requirement 2: Consume Replay Relocation
+
+**User Story:** As a GM, I want the "Consume Replay" checkbox to be inside the Advanced section, so that the character card's default view is cleaner.
+
+#### Acceptance Criteria
+
+1. THE Advanced_Section SHALL contain the existing Consume Replay checkbox for each character
+2. THE Consume Replay checkbox SHALL retain its current `name` attribute format (`characters.{id}.consumeReplay`) after relocation
+3. THE Consume Replay checkbox SHALL retain its current auto-save and form data extraction behavior after relocation
+4. THE Consume Replay checkbox SHALL retain its current tooltip text after relocation
+
+### Requirement 3: Override XP Checkbox and Input
+
+**User Story:** As a GM, I want to override the calculated XP for a specific character, so that I can account for feats, boons, or other adjustments that modify XP earned.
+
+#### Acceptance Criteria
+
+1. THE Advanced_Section SHALL contain an Override_XP_Checkbox labeled "Override XP"
+2. THE Advanced_Section SHALL contain an Override_XP_Input next to the Override_XP_Checkbox
+3. WHILE the Override_XP_Checkbox is unchecked, THE Override_XP_Input SHALL be disabled (not accepting input)
+4. WHEN the GM checks the Override_XP_Checkbox, THE Override_XP_Input SHALL become enabled
+5. WHEN the GM checks the Override_XP_Checkbox, THE Calculated_XP_Label on the Character_Card SHALL display with strikethrough styling
+6. WHEN the GM unchecks the Override_XP_Checkbox, THE Override_XP_Input SHALL become disabled and THE Calculated_XP_Label SHALL remove the strikethrough styling
+7. THE Override_XP_Input SHALL accept numeric values
+
+### Requirement 4: Override Currency Checkbox and Input
+
+**User Story:** As a GM, I want to override the calculated currency gained for a specific character, so that I can account for feats, boons, or downtime activities that modify gold or credits earned.
+
+#### Acceptance Criteria
+
+1. THE Advanced_Section SHALL contain an Override_Currency_Checkbox
+2. WHILE the active game system is Pathfinder, THE Override_Currency_Checkbox SHALL be labeled "Override GP Gained"
+3. WHILE the active game system is Starfinder, THE Override_Currency_Checkbox SHALL be labeled "Override Credits Gained"
+4. THE Advanced_Section SHALL contain an Override_Currency_Input next to the Override_Currency_Checkbox
+5. WHILE the Override_Currency_Checkbox is unchecked, THE Override_Currency_Input SHALL be disabled (not accepting input)
+6. WHEN the GM checks the Override_Currency_Checkbox, THE Override_Currency_Input SHALL become enabled
+7. WHEN the GM checks the Override_Currency_Checkbox, THE Calculated_Currency_Label and THE Earned_Income_Label on the Character_Card SHALL display with strikethrough styling
+8. WHEN the GM unchecks the Override_Currency_Checkbox, THE Override_Currency_Input SHALL become disabled and THE Calculated_Currency_Label and THE Earned_Income_Label SHALL remove the strikethrough styling
+9. THE Override_Currency_Input SHALL accept numeric values with up to two decimal places for Pathfinder and whole numbers for Starfinder
+
+### Requirement 5: Override Values in Chronicle Generation
+
+**User Story:** As a GM, I want override values to replace the calculated values on the generated chronicle PDF, so that the printed chronicle reflects the correct adjusted amounts.
+
+#### Acceptance Criteria
+
+1. WHEN the Override_XP_Checkbox is checked, THE Chronicle_Generator SHALL use the Override_XP_Input value (including zero) as `xp_gained` instead of the shared `xpEarned` value for that character
+2. WHEN the Override_Currency_Checkbox is checked, THE Chronicle_Generator SHALL use the Override_Currency_Input value (including zero) as `currency_gained` instead of the calculated currency gained for that character
+3. WHEN the Override_XP_Checkbox is unchecked, THE Chronicle_Generator SHALL use the standard calculated `xp_gained` value for that character
+4. WHEN the Override_Currency_Checkbox is unchecked, THE Chronicle_Generator SHALL use the standard calculated `currency_gained` value for that character
+
+### Requirement 6: Override Data Persistence
+
+**User Story:** As a GM, I want override settings to persist when the form is reloaded, so that I do not lose override values between sessions.
+
+#### Acceptance Criteria
+
+1. WHEN the GM changes an override checkbox or input value, THE Society_Tab SHALL auto-save the override state and value to the character's stored data alongside existing fields
+2. WHEN the form is loaded with previously saved data that includes override values, THE Society_Tab SHALL restore the override checkbox states, input values, strikethrough styling, and input enabled/disabled states
+3. WHEN the Clear Data button is pressed, THE Society_Tab SHALL reset all override checkboxes to unchecked and all override input values to empty
+
+### Requirement 7: Override Data in Session Reporting
+
+**User Story:** As a GM, I want the session report to reflect override values when they are active, so that the copied session report data is accurate.
+
+#### Acceptance Criteria
+
+1. WHEN the Override_XP_Checkbox is checked for a character, THE Session_Report_Builder SHALL use the Override_XP_Input value as the XP earned for that character in the session report
+2. WHEN the Override_Currency_Checkbox is checked for a character, THE Session_Report_Builder SHALL use the Override_Currency_Input value as the currency gained for that character in the session report
+3. WHEN no override is active for a character, THE Session_Report_Builder SHALL use the standard calculated values
+
+### Requirement 8: Per-Character Scope
+
+**User Story:** As a GM, I want overrides to apply independently per character, so that I can override values for one character without affecting others.
+
+#### Acceptance Criteria
+
+1. THE Override_XP_Checkbox and Override_XP_Input SHALL be independent for each Character_Card
+2. THE Override_Currency_Checkbox and Override_Currency_Input SHALL be independent for each Character_Card
+3. WHEN the GM enables an override for one character, THE Society_Tab SHALL leave all other characters' override states unchanged
+4. THE GM_Character card SHALL support the same override controls as Party_Actor cards

--- a/.kiro/specs/gm-override-values/requirements.md
+++ b/.kiro/specs/gm-override-values/requirements.md
@@ -69,7 +69,7 @@ The PFS Chronicle Generator automatically calculates `xp_gained` and `currency_g
 
 1. THE Advanced_Section SHALL contain an Override_Currency_Checkbox
 2. WHILE the active game system is Pathfinder, THE Override_Currency_Checkbox SHALL be labeled "Override GP Gained"
-3. WHILE the active game system is Starfinder, THE Override_Currency_Checkbox SHALL be labeled "Override Credits Gained"
+3. WHILE the active game system is Starfinder, THE Override_Currency_Checkbox SHALL be labeled "Override Credits"
 4. THE Advanced_Section SHALL contain an Override_Currency_Input next to the Override_Currency_Checkbox
 5. WHILE the Override_Currency_Checkbox is unchecked, THE Override_Currency_Input SHALL be disabled (not accepting input)
 6. WHEN the GM checks the Override_Currency_Checkbox, THE Override_Currency_Input SHALL become enabled

--- a/.kiro/specs/gm-override-values/tasks.md
+++ b/.kiro/specs/gm-override-values/tasks.md
@@ -181,7 +181,7 @@ Add override controls for XP and currency values to each character card in the S
 - [x] 15. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [-] 16. Commit event listener wiring
+- [x] 16. Commit event listener wiring
   - Commit with message `feat: Wire override event listeners and form initialization`
   - Stage all files changed in task 14 plus updated spec task file
 

--- a/.kiro/specs/gm-override-values/tasks.md
+++ b/.kiro/specs/gm-override-values/tasks.md
@@ -57,12 +57,12 @@ Add override controls for XP and currency values to each character card in the S
 - [x] 4. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [-] 5. Commit override handler module
+- [x] 5. Commit override handler module
   - Commit with message `feat: Add override handler module with data model and selectors`
   - Stage all files changed in tasks 2 and 3 plus updated spec task file
 
 - [ ] 6. Add Advanced section to template and extend collapsible handler
-  - [~] 6.1 Add Advanced collapsible section to each character card in `templates/party-chronicle-filling.hbs`
+  - [x] 6.1 Add Advanced collapsible section to each character card in `templates/party-chronicle-filling.hbs`
     - Add an Advanced collapsible section (`data-section-id="advanced-{{this.id}}"`) within each party member's `character-fields` div, containing:
       - Relocated Consume Replay checkbox (remove from current position, place inside Advanced section) retaining existing `name` attribute format and tooltip
       - Override XP checkbox (`name="characters.{{this.id}}.overrideXp"`) and numeric input (`name="characters.{{this.id}}.overrideXpValue"`, `min="0"`, `step="1"`, `disabled`)
@@ -74,12 +74,12 @@ Add override controls for XP and currency values to each character card in the S
     - Restore saved override checkbox states and input values from `savedData.characters` / `gmCharacterFields`
     - _Requirements: 1.1, 1.2, 1.3, 1.6, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.7, 4.1, 4.2, 4.3, 4.4, 4.9, 8.4_
 
-  - [~] 6.2 Extend collapsible section handler to support dynamic Advanced section IDs
+  - [x] 6.2 Extend collapsible section handler to support dynamic Advanced section IDs
     - Update `isValidSectionId()` in `handlers/collapsible-section-handlers.ts` to accept section IDs matching the `advanced-` prefix pattern in addition to existing static IDs
     - Update `initializeCollapseSections()` to discover and initialize `advanced-*` sections from the DOM (default state: collapsed)
     - _Requirements: 1.3, 1.4, 1.5, 1.6_
 
-  - [~] 6.3 Write unit tests for Advanced section template rendering and collapsible handler
+  - [x] 6.3 Write unit tests for Advanced section template rendering and collapsible handler
     - Test Advanced section renders within each character card (party member and GM character)
     - Test Advanced section has title "Advanced" and is collapsed by default
     - Test Consume Replay checkbox is inside Advanced section with correct `name` attribute
@@ -90,10 +90,10 @@ Add override controls for XP and currency values to each character card in the S
     - Test `initializeCollapseSections` initializes Advanced sections as collapsed
     - _Requirements: 1.1, 1.2, 1.3, 1.5, 1.6, 2.1, 2.2, 3.1, 3.2, 3.7, 4.2, 4.3, 4.9, 8.4_
 
-- [~] 7. Checkpoint - Ensure all tests pass
+- [x] 7. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [~] 8. Commit Advanced section and collapsible handler
+- [-] 8. Commit Advanced section and collapsible handler
   - Commit with message `feat: Add Advanced collapsible section with override UI controls`
   - Stage all files changed in task 6 plus updated spec task file
 

--- a/.kiro/specs/gm-override-values/tasks.md
+++ b/.kiro/specs/gm-override-values/tasks.md
@@ -1,0 +1,201 @@
+# Implementation Plan: GM Override Values
+
+## Overview
+
+Add override controls for XP and currency values to each character card in the Society tab. The implementation extends the existing per-character data model with four new fields, introduces a new `override-handlers.ts` module for checkbox toggle logic, relocates the Consume Replay checkbox into a new collapsible "Advanced" section, and integrates override-aware logic into the chronicle generation and session report pipelines. All changes follow the hybrid ApplicationV2 pattern and reuse the existing collapsible section infrastructure.
+
+## Tasks
+
+- [ ] 1. Initial spec commit
+  - [x] 1.1 Create feature branch `feat/gm-override-values` from current branch
+  - [-] 1.2 Commit spec files with message `docs: Add gm-override-values spec`
+    - Stage `.kiro/specs/gm-override-values/requirements.md`, `.kiro/specs/gm-override-values/design.md`, `.kiro/specs/gm-override-values/tasks.md`, `.kiro/specs/gm-override-values/.config.kiro`
+
+- [ ] 2. Extend data model and DOM selectors for override fields
+  - [~] 2.1 Add override fields to `UniqueFields` interface in `model/party-chronicle-types.ts`
+    - Add `overrideXp: boolean`, `overrideXpValue: number`, `overrideCurrency: boolean`, `overrideCurrencyValue: number` to the `UniqueFields` interface
+    - _Requirements: 3.1, 3.2, 4.1, 4.4, 8.1, 8.2_
+
+  - [~] 2.2 Add override DOM selectors to `constants/dom-selectors.ts`
+    - Add character field selectors: `OVERRIDE_XP`, `OVERRIDE_XP_VALUE`, `OVERRIDE_CURRENCY`, `OVERRIDE_CURRENCY_VALUE`, `CALCULATED_XP_LABEL`, `CALCULATED_CURRENCY_LABEL`, `EARNED_INCOME_LABEL` as functions of `characterId`
+    - Add character field patterns: `OVERRIDE_XP_ALL`, `OVERRIDE_CURRENCY_ALL` for `querySelectorAll`
+    - Add `STRIKETHROUGH_OVERRIDE` to `CSS_CLASSES`
+    - _Requirements: 3.1, 3.2, 4.1, 4.4_
+
+  - [~] 2.3 Add `.strikethrough-override` CSS class to `css/style.css`
+    - Add a `.strikethrough-override` class with `text-decoration: line-through` styling
+    - _Requirements: 3.5, 3.6, 4.7, 4.8_
+
+  - [~] 2.4 Extend `buildDefaultCharacterFields()` in `handlers/event-listener-helpers.ts`
+    - Add `overrideXp: false`, `overrideXpValue: 0`, `overrideCurrency: false`, `overrideCurrencyValue: 0` to the default character fields object
+    - _Requirements: 6.3_
+
+- [ ] 3. Create override handler module and tests
+  - [~] 3.1 Create `handlers/override-handlers.ts` with checkbox toggle and initialization logic
+    - Implement `handleOverrideXpChange(characterId, container)`: toggle Override_XP_Input disabled state, toggle `.strikethrough-override` on Calculated_XP_Label, trigger auto-save via `handleFieldChange`
+    - Implement `handleOverrideCurrencyChange(characterId, container)`: toggle Override_Currency_Input disabled state, toggle `.strikethrough-override` on Calculated_Currency_Label and Earned_Income_Label, trigger auto-save
+    - Implement `initializeOverrideStates(container)`: read all override checkboxes, apply correct disabled/enabled and strikethrough states from saved data on form load
+    - _Requirements: 3.3, 3.4, 3.5, 3.6, 4.5, 4.6, 4.7, 4.8, 6.2_
+
+  - [ ]* 3.2 Write property test: XP override checkbox controls input state and strikethrough
+    - **Property 1: XP override checkbox controls input state and strikethrough**
+    - **Validates: Requirements 3.3, 3.4, 3.5, 3.6**
+
+  - [ ]* 3.3 Write property test: Currency override checkbox controls input state and strikethrough
+    - **Property 2: Currency override checkbox controls input state and strikethrough**
+    - **Validates: Requirements 4.5, 4.6, 4.7, 4.8**
+
+  - [~] 3.4 Write unit tests for `handlers/override-handlers.ts`
+    - Test `handleOverrideXpChange` enables input and adds strikethrough when checked
+    - Test `handleOverrideXpChange` disables input and removes strikethrough when unchecked
+    - Test `handleOverrideCurrencyChange` enables input and adds strikethrough to currency label and earned income label when checked
+    - Test `handleOverrideCurrencyChange` disables input and removes strikethrough when unchecked
+    - Test `initializeOverrideStates` applies correct states from saved data
+    - Test override controls are independent per character
+    - _Requirements: 3.3, 3.4, 3.5, 3.6, 4.5, 4.6, 4.7, 4.8, 6.2, 8.1, 8.2_
+
+- [~] 4. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [~] 5. Commit override handler module
+  - Commit with message `feat: Add override handler module with data model and selectors`
+  - Stage all files changed in tasks 2 and 3 plus updated spec task file
+
+- [ ] 6. Add Advanced section to template and extend collapsible handler
+  - [~] 6.1 Add Advanced collapsible section to each character card in `templates/party-chronicle-filling.hbs`
+    - Add an Advanced collapsible section (`data-section-id="advanced-{{this.id}}"`) within each party member's `character-fields` div, containing:
+      - Relocated Consume Replay checkbox (remove from current position, place inside Advanced section) retaining existing `name` attribute format and tooltip
+      - Override XP checkbox (`name="characters.{{this.id}}.overrideXp"`) and numeric input (`name="characters.{{this.id}}.overrideXpValue"`, `min="0"`, `step="1"`, `disabled`)
+      - Override Currency checkbox (`name="characters.{{this.id}}.overrideCurrency"`) with system-aware label ("Override GP Gained" for PF2e, "Override Credits Gained" for SF2e) and numeric input (`name="characters.{{this.id}}.overrideCurrencyValue"`, `min="0"`, system-aware `step`, `disabled`)
+    - Add the same Advanced section to the GM character card section
+    - Add `calculated-xp-label` CSS class to the XP display element on each character card
+    - Add `calculated-currency-label` CSS class to the treasure bundle value / credits awarded display element on each character card
+    - Add `earned-income-label` CSS class to the "Earned Income" label element on each character card
+    - Restore saved override checkbox states and input values from `savedData.characters` / `gmCharacterFields`
+    - _Requirements: 1.1, 1.2, 1.3, 1.6, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.7, 4.1, 4.2, 4.3, 4.4, 4.9, 8.4_
+
+  - [~] 6.2 Extend collapsible section handler to support dynamic Advanced section IDs
+    - Update `isValidSectionId()` in `handlers/collapsible-section-handlers.ts` to accept section IDs matching the `advanced-` prefix pattern in addition to existing static IDs
+    - Update `initializeCollapseSections()` to discover and initialize `advanced-*` sections from the DOM (default state: collapsed)
+    - _Requirements: 1.3, 1.4, 1.5, 1.6_
+
+  - [~] 6.3 Write unit tests for Advanced section template rendering and collapsible handler
+    - Test Advanced section renders within each character card (party member and GM character)
+    - Test Advanced section has title "Advanced" and is collapsed by default
+    - Test Consume Replay checkbox is inside Advanced section with correct `name` attribute
+    - Test Override XP checkbox and input render with correct attributes
+    - Test Override Currency label is system-aware ("Override GP Gained" vs "Override Credits Gained")
+    - Test Override Currency input step is `0.01` for Pathfinder and `1` for Starfinder
+    - Test `isValidSectionId` accepts `advanced-{characterId}` patterns
+    - Test `initializeCollapseSections` initializes Advanced sections as collapsed
+    - _Requirements: 1.1, 1.2, 1.3, 1.5, 1.6, 2.1, 2.2, 3.1, 3.2, 3.7, 4.2, 4.3, 4.9, 8.4_
+
+- [~] 7. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [~] 8. Commit Advanced section and collapsible handler
+  - Commit with message `feat: Add Advanced collapsible section with override UI controls`
+  - Stage all files changed in task 6 plus updated spec task file
+
+- [ ] 9. Extend form data extraction and persistence
+  - [~] 9.1 Extend `extractFormData()` in `handlers/form-data-extraction.ts` to read override fields
+    - Read `overrideXp` checkbox checked state from `input[name="characters.{id}.overrideXp"]`
+    - Read `overrideXpValue` numeric value from `input[name="characters.{id}.overrideXpValue"]`
+    - Read `overrideCurrency` checkbox checked state from `input[name="characters.{id}.overrideCurrency"]`
+    - Read `overrideCurrencyValue` numeric value from `input[name="characters.{id}.overrideCurrencyValue"]`
+    - Use `|| false` for checkboxes and `|| 0` for numeric values as safe defaults for migration
+    - _Requirements: 6.1, 6.2_
+
+  - [ ]* 9.2 Write property test: Override data persistence round-trip
+    - **Property 5: Override data persistence round-trip**
+    - **Validates: Requirements 6.1, 6.2**
+
+  - [ ]* 9.3 Write property test: Clear resets all overrides
+    - **Property 6: Clear resets all overrides**
+    - **Validates: Requirements 6.3**
+
+  - [ ]* 9.4 Write property test: Per-character override independence
+    - **Property 8: Per-character override independence**
+    - **Validates: Requirements 8.1, 8.2, 8.3**
+
+- [ ] 10. Extend chronicle generation mapper for override-aware values
+  - [~] 10.1 Extend `mapToCharacterData()` in `model/party-chronicle-mapper.ts`
+    - When `unique.overrideXp === true`: set `xp_gained = unique.overrideXpValue` instead of `shared.xpEarned`
+    - When `unique.overrideCurrency === true`: set `currency_gained = unique.overrideCurrencyValue` instead of the calculated `treasureBundleValue + earnedIncome`
+    - When overrides are not active, use the existing calculated values unchanged
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [ ]* 10.2 Write property test: XP override in chronicle generation
+    - **Property 3: XP override in chronicle generation**
+    - **Validates: Requirements 5.1, 5.3**
+
+  - [ ]* 10.3 Write property test: Currency override in chronicle generation
+    - **Property 4: Currency override in chronicle generation**
+    - **Validates: Requirements 5.2, 5.4**
+
+  - [~] 10.4 Write unit tests for override-aware `mapToCharacterData()`
+    - Test XP override active: `xp_gained` equals `overrideXpValue` (including zero)
+    - Test XP override inactive: `xp_gained` equals `shared.xpEarned`
+    - Test currency override active: `currency_gained` equals `overrideCurrencyValue` (including zero)
+    - Test currency override inactive: `currency_gained` equals calculated value
+    - Test both overrides active simultaneously
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+- [ ] 11. Extend session report builder for override-aware values
+  - [~] 11.1 Extend `buildSessionReport()` in `model/session-report-builder.ts`
+    - Extend `buildSignUp` and `buildGmSignUp` to accept override fields from `UniqueFields`
+    - When `overrideXp` is true, use `overrideXpValue` as the XP for that character in the session report
+    - When `overrideCurrency` is true, use `overrideCurrencyValue` as the currency for that character in the session report
+    - When overrides are not active, use the standard calculated values
+    - _Requirements: 7.1, 7.2, 7.3_
+
+  - [ ]* 11.2 Write property test: Override values in session report
+    - **Property 7: Override values in session report**
+    - **Validates: Requirements 7.1, 7.2, 7.3**
+
+  - [~] 11.3 Write unit tests for override-aware session report
+    - Test session report uses override XP when active
+    - Test session report uses override currency when active
+    - Test session report uses calculated values when overrides are inactive
+    - Test GM character override values in session report
+    - _Requirements: 7.1, 7.2, 7.3_
+
+- [~] 12. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [~] 13. Commit extraction, generation, and session report changes
+  - Commit with message `feat: Add override-aware chronicle generation and session reporting`
+  - Stage all files changed in tasks 9, 10, and 11 plus updated spec task file
+
+- [ ] 14. Wire override event listeners into main.ts
+  - [~] 14.1 Extend `attachEventListeners()` in `main.ts`
+    - Import `handleOverrideXpChange`, `handleOverrideCurrencyChange`, and `initializeOverrideStates` from `handlers/override-handlers.ts`
+    - Create and export `attachOverrideListeners(container)` in `handlers/event-listener-helpers.ts` that attaches change listeners to all override XP and currency checkboxes using `CHARACTER_FIELD_PATTERNS.OVERRIDE_XP_ALL` and `CHARACTER_FIELD_PATTERNS.OVERRIDE_CURRENCY_ALL`
+    - Call `attachOverrideListeners(container)` from `attachEventListeners()` in `main.ts`
+    - _Requirements: 1.4, 1.5, 3.3, 3.4, 4.5, 4.6_
+
+  - [~] 14.2 Extend `initializeForm()` in `main.ts`
+    - Call `initializeOverrideStates(container)` after `initializeCollapseSections(container)` to restore override checkbox states, input values, disabled states, and strikethrough styling from saved data on form load
+    - _Requirements: 6.2_
+
+- [~] 15. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [~] 16. Commit event listener wiring
+  - Commit with message `feat: Wire override event listeners and form initialization`
+  - Stage all files changed in task 14 plus updated spec task file
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document using `fast-check`
+- Unit tests validate specific examples and edge cases
+- The design uses TypeScript throughout, matching the existing codebase
+- Override fields are stored in `UniqueFields` (per-character), not `SharedFields`
+- The Advanced section reuses the existing `Collapsible_Section_Handler` infrastructure with dynamic `advanced-{characterId}` section IDs
+- Consume Replay relocation is a template-only change — no logic changes needed
+- Git commits follow conventional commit format with signed commits (`git commit -S`)
+- First commit is `docs:` with spec files per coding standards
+- Subsequent commits bundle implementation + tests as coherent units at each checkpoint

--- a/.kiro/specs/gm-override-values/tasks.md
+++ b/.kiro/specs/gm-override-values/tasks.md
@@ -6,32 +6,32 @@ Add override controls for XP and currency values to each character card in the S
 
 ## Tasks
 
-- [ ] 1. Initial spec commit
+- [x] 1. Initial spec commit
   - [x] 1.1 Create feature branch `feat/gm-override-values` from current branch
-  - [-] 1.2 Commit spec files with message `docs: Add gm-override-values spec`
+  - [x] 1.2 Commit spec files with message `docs: Add gm-override-values spec`
     - Stage `.kiro/specs/gm-override-values/requirements.md`, `.kiro/specs/gm-override-values/design.md`, `.kiro/specs/gm-override-values/tasks.md`, `.kiro/specs/gm-override-values/.config.kiro`
 
-- [ ] 2. Extend data model and DOM selectors for override fields
-  - [~] 2.1 Add override fields to `UniqueFields` interface in `model/party-chronicle-types.ts`
+- [x] 2. Extend data model and DOM selectors for override fields
+  - [x] 2.1 Add override fields to `UniqueFields` interface in `model/party-chronicle-types.ts`
     - Add `overrideXp: boolean`, `overrideXpValue: number`, `overrideCurrency: boolean`, `overrideCurrencyValue: number` to the `UniqueFields` interface
     - _Requirements: 3.1, 3.2, 4.1, 4.4, 8.1, 8.2_
 
-  - [~] 2.2 Add override DOM selectors to `constants/dom-selectors.ts`
+  - [x] 2.2 Add override DOM selectors to `constants/dom-selectors.ts`
     - Add character field selectors: `OVERRIDE_XP`, `OVERRIDE_XP_VALUE`, `OVERRIDE_CURRENCY`, `OVERRIDE_CURRENCY_VALUE`, `CALCULATED_XP_LABEL`, `CALCULATED_CURRENCY_LABEL`, `EARNED_INCOME_LABEL` as functions of `characterId`
     - Add character field patterns: `OVERRIDE_XP_ALL`, `OVERRIDE_CURRENCY_ALL` for `querySelectorAll`
     - Add `STRIKETHROUGH_OVERRIDE` to `CSS_CLASSES`
     - _Requirements: 3.1, 3.2, 4.1, 4.4_
 
-  - [~] 2.3 Add `.strikethrough-override` CSS class to `css/style.css`
+  - [x] 2.3 Add `.strikethrough-override` CSS class to `css/style.css`
     - Add a `.strikethrough-override` class with `text-decoration: line-through` styling
     - _Requirements: 3.5, 3.6, 4.7, 4.8_
 
-  - [~] 2.4 Extend `buildDefaultCharacterFields()` in `handlers/event-listener-helpers.ts`
+  - [x] 2.4 Extend `buildDefaultCharacterFields()` in `handlers/event-listener-helpers.ts`
     - Add `overrideXp: false`, `overrideXpValue: 0`, `overrideCurrency: false`, `overrideCurrencyValue: 0` to the default character fields object
     - _Requirements: 6.3_
 
-- [ ] 3. Create override handler module and tests
-  - [~] 3.1 Create `handlers/override-handlers.ts` with checkbox toggle and initialization logic
+- [x] 3. Create override handler module and tests
+  - [x] 3.1 Create `handlers/override-handlers.ts` with checkbox toggle and initialization logic
     - Implement `handleOverrideXpChange(characterId, container)`: toggle Override_XP_Input disabled state, toggle `.strikethrough-override` on Calculated_XP_Label, trigger auto-save via `handleFieldChange`
     - Implement `handleOverrideCurrencyChange(characterId, container)`: toggle Override_Currency_Input disabled state, toggle `.strikethrough-override` on Calculated_Currency_Label and Earned_Income_Label, trigger auto-save
     - Implement `initializeOverrideStates(container)`: read all override checkboxes, apply correct disabled/enabled and strikethrough states from saved data on form load
@@ -45,7 +45,7 @@ Add override controls for XP and currency values to each character card in the S
     - **Property 2: Currency override checkbox controls input state and strikethrough**
     - **Validates: Requirements 4.5, 4.6, 4.7, 4.8**
 
-  - [~] 3.4 Write unit tests for `handlers/override-handlers.ts`
+  - [x] 3.4 Write unit tests for `handlers/override-handlers.ts`
     - Test `handleOverrideXpChange` enables input and adds strikethrough when checked
     - Test `handleOverrideXpChange` disables input and removes strikethrough when unchecked
     - Test `handleOverrideCurrencyChange` enables input and adds strikethrough to currency label and earned income label when checked
@@ -54,10 +54,10 @@ Add override controls for XP and currency values to each character card in the S
     - Test override controls are independent per character
     - _Requirements: 3.3, 3.4, 3.5, 3.6, 4.5, 4.6, 4.7, 4.8, 6.2, 8.1, 8.2_
 
-- [~] 4. Checkpoint - Ensure all tests pass
+- [x] 4. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [~] 5. Commit override handler module
+- [-] 5. Commit override handler module
   - Commit with message `feat: Add override handler module with data model and selectors`
   - Stage all files changed in tasks 2 and 3 plus updated spec task file
 

--- a/.kiro/specs/gm-override-values/tasks.md
+++ b/.kiro/specs/gm-override-values/tasks.md
@@ -163,25 +163,25 @@ Add override controls for XP and currency values to each character card in the S
 - [x] 12. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [-] 13. Commit extraction, generation, and session report changes
+- [x] 13. Commit extraction, generation, and session report changes
   - Commit with message `feat: Add override-aware chronicle generation and session reporting`
   - Stage all files changed in tasks 9, 10, and 11 plus updated spec task file
 
-- [ ] 14. Wire override event listeners into main.ts
-  - [~] 14.1 Extend `attachEventListeners()` in `main.ts`
+- [x] 14. Wire override event listeners into main.ts
+  - [x] 14.1 Extend `attachEventListeners()` in `main.ts`
     - Import `handleOverrideXpChange`, `handleOverrideCurrencyChange`, and `initializeOverrideStates` from `handlers/override-handlers.ts`
     - Create and export `attachOverrideListeners(container)` in `handlers/event-listener-helpers.ts` that attaches change listeners to all override XP and currency checkboxes using `CHARACTER_FIELD_PATTERNS.OVERRIDE_XP_ALL` and `CHARACTER_FIELD_PATTERNS.OVERRIDE_CURRENCY_ALL`
     - Call `attachOverrideListeners(container)` from `attachEventListeners()` in `main.ts`
     - _Requirements: 1.4, 1.5, 3.3, 3.4, 4.5, 4.6_
 
-  - [~] 14.2 Extend `initializeForm()` in `main.ts`
+  - [x] 14.2 Extend `initializeForm()` in `main.ts`
     - Call `initializeOverrideStates(container)` after `initializeCollapseSections(container)` to restore override checkbox states, input values, disabled states, and strikethrough styling from saved data on form load
     - _Requirements: 6.2_
 
-- [~] 15. Final checkpoint - Ensure all tests pass
+- [x] 15. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [~] 16. Commit event listener wiring
+- [-] 16. Commit event listener wiring
   - Commit with message `feat: Wire override event listeners and form initialization`
   - Stage all files changed in task 14 plus updated spec task file
 

--- a/.kiro/specs/gm-override-values/tasks.md
+++ b/.kiro/specs/gm-override-values/tasks.md
@@ -61,7 +61,7 @@ Add override controls for XP and currency values to each character card in the S
   - Commit with message `feat: Add override handler module with data model and selectors`
   - Stage all files changed in tasks 2 and 3 plus updated spec task file
 
-- [ ] 6. Add Advanced section to template and extend collapsible handler
+- [x] 6. Add Advanced section to template and extend collapsible handler
   - [x] 6.1 Add Advanced collapsible section to each character card in `templates/party-chronicle-filling.hbs`
     - Add an Advanced collapsible section (`data-section-id="advanced-{{this.id}}"`) within each party member's `character-fields` div, containing:
       - Relocated Consume Replay checkbox (remove from current position, place inside Advanced section) retaining existing `name` attribute format and tooltip
@@ -93,12 +93,12 @@ Add override controls for XP and currency values to each character card in the S
 - [x] 7. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [-] 8. Commit Advanced section and collapsible handler
+- [x] 8. Commit Advanced section and collapsible handler
   - Commit with message `feat: Add Advanced collapsible section with override UI controls`
   - Stage all files changed in task 6 plus updated spec task file
 
-- [ ] 9. Extend form data extraction and persistence
-  - [~] 9.1 Extend `extractFormData()` in `handlers/form-data-extraction.ts` to read override fields
+- [x] 9. Extend form data extraction and persistence
+  - [x] 9.1 Extend `extractFormData()` in `handlers/form-data-extraction.ts` to read override fields
     - Read `overrideXp` checkbox checked state from `input[name="characters.{id}.overrideXp"]`
     - Read `overrideXpValue` numeric value from `input[name="characters.{id}.overrideXpValue"]`
     - Read `overrideCurrency` checkbox checked state from `input[name="characters.{id}.overrideCurrency"]`
@@ -118,8 +118,8 @@ Add override controls for XP and currency values to each character card in the S
     - **Property 8: Per-character override independence**
     - **Validates: Requirements 8.1, 8.2, 8.3**
 
-- [ ] 10. Extend chronicle generation mapper for override-aware values
-  - [~] 10.1 Extend `mapToCharacterData()` in `model/party-chronicle-mapper.ts`
+- [x] 10. Extend chronicle generation mapper for override-aware values
+  - [x] 10.1 Extend `mapToCharacterData()` in `model/party-chronicle-mapper.ts`
     - When `unique.overrideXp === true`: set `xp_gained = unique.overrideXpValue` instead of `shared.xpEarned`
     - When `unique.overrideCurrency === true`: set `currency_gained = unique.overrideCurrencyValue` instead of the calculated `treasureBundleValue + earnedIncome`
     - When overrides are not active, use the existing calculated values unchanged
@@ -133,7 +133,7 @@ Add override controls for XP and currency values to each character card in the S
     - **Property 4: Currency override in chronicle generation**
     - **Validates: Requirements 5.2, 5.4**
 
-  - [~] 10.4 Write unit tests for override-aware `mapToCharacterData()`
+  - [x] 10.4 Write unit tests for override-aware `mapToCharacterData()`
     - Test XP override active: `xp_gained` equals `overrideXpValue` (including zero)
     - Test XP override inactive: `xp_gained` equals `shared.xpEarned`
     - Test currency override active: `currency_gained` equals `overrideCurrencyValue` (including zero)
@@ -141,8 +141,8 @@ Add override controls for XP and currency values to each character card in the S
     - Test both overrides active simultaneously
     - _Requirements: 5.1, 5.2, 5.3, 5.4_
 
-- [ ] 11. Extend session report builder for override-aware values
-  - [~] 11.1 Extend `buildSessionReport()` in `model/session-report-builder.ts`
+- [x] 11. Extend session report builder for override-aware values
+  - [x] 11.1 Extend `buildSessionReport()` in `model/session-report-builder.ts`
     - Extend `buildSignUp` and `buildGmSignUp` to accept override fields from `UniqueFields`
     - When `overrideXp` is true, use `overrideXpValue` as the XP for that character in the session report
     - When `overrideCurrency` is true, use `overrideCurrencyValue` as the currency for that character in the session report
@@ -153,17 +153,17 @@ Add override controls for XP and currency values to each character card in the S
     - **Property 7: Override values in session report**
     - **Validates: Requirements 7.1, 7.2, 7.3**
 
-  - [~] 11.3 Write unit tests for override-aware session report
+  - [x] 11.3 Write unit tests for override-aware session report
     - Test session report uses override XP when active
     - Test session report uses override currency when active
     - Test session report uses calculated values when overrides are inactive
     - Test GM character override values in session report
     - _Requirements: 7.1, 7.2, 7.3_
 
-- [~] 12. Checkpoint - Ensure all tests pass
+- [x] 12. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [~] 13. Commit extraction, generation, and session report changes
+- [-] 13. Commit extraction, generation, and session report changes
   - Commit with message `feat: Add override-aware chronicle generation and session reporting`
   - Stage all files changed in tasks 9, 10, and 11 plus updated spec task file
 

--- a/css/style.css
+++ b/css/style.css
@@ -648,3 +648,9 @@
     color: #d32f2f;
     border-color: #d32f2f;
 }
+
+/* Override Strikethrough Styling */
+/* Requirements: gm-override-values 3.5, 3.6, 4.7, 4.8 */
+.sheet.party [data-tab=pfs] .strikethrough-override {
+    text-decoration: line-through;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -558,6 +558,62 @@
     display: none;
 }
 
+/* Advanced Section (per-character collapsible in content area) */
+/* Requirements: gm-override-values 1.1, 1.2, 1.3, 1.4, 1.5, 1.6 */
+.sheet.party [data-tab=pfs] .content .advanced-section {
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--color-border-light-tertiary, #ccc);
+    padding-top: 0.25rem;
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section .collapsible-header {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 0.25rem 0;
+    user-select: none;
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section .collapsible-header:hover {
+    text-decoration: underline;
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section .collapsible-header:focus {
+    outline: 2px solid #4a90e2;
+    outline-offset: 2px;
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section .collapsible-header .chevron {
+    flex-shrink: 0;
+    transition: transform 0.2s ease;
+    margin-right: 0.35rem;
+    font-size: 0.75em;
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section .collapsible-header .chevron::before {
+    content: '▼';
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section.collapsed .chevron::before {
+    content: '▶';
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section .collapsible-header .section-title {
+    font-weight: bold;
+    font-size: 0.9em;
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section .collapsible-content {
+    overflow: hidden;
+    transition: max-height 0.3s ease, opacity 0.2s ease;
+}
+
+.sheet.party [data-tab=pfs] .content .advanced-section.collapsed .collapsible-content {
+    max-height: 0;
+    opacity: 0;
+    display: none;
+}
+
 /* Task Level help icon styling - uses Foundry's built-in tooltip system */
 .sheet.party [data-tab=pfs] .activities .member-activity .form-group label .fa-question-circle {
   margin-left: 4px;

--- a/scripts/constants/dom-selectors.ts
+++ b/scripts/constants/dom-selectors.ts
@@ -49,7 +49,7 @@ export const CHARACTER_FIELD_SELECTORS = {
   OVERRIDE_CURRENCY_VALUE: (characterId: string) => `input[name="characters.${characterId}.overrideCurrencyValue"]`,
   CALCULATED_XP_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .calculated-xp-label`,
   CALCULATED_CURRENCY_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .calculated-currency-label`,
-  EARNED_INCOME_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .earned-income-label`,
+  EARNED_INCOME_VALUE: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .earned-income-value`,
 } as const;
 
 /**

--- a/scripts/constants/dom-selectors.ts
+++ b/scripts/constants/dom-selectors.ts
@@ -43,6 +43,13 @@ export const CHARACTER_FIELD_SELECTORS = {
   TREASURE_BUNDLE_DISPLAY: (characterId: string) => `#treasureBundleGpDisplay-${characterId}`,
   CONSUME_REPLAY: (characterId: string) => `input[name="characters.${characterId}.consumeReplay"]`,
   FACTION_DISPLAY: (characterId: string) => `#factionDisplay-${characterId}`,
+  OVERRIDE_XP: (characterId: string) => `input[name="characters.${characterId}.overrideXp"]`,
+  OVERRIDE_XP_VALUE: (characterId: string) => `input[name="characters.${characterId}.overrideXpValue"]`,
+  OVERRIDE_CURRENCY: (characterId: string) => `input[name="characters.${characterId}.overrideCurrency"]`,
+  OVERRIDE_CURRENCY_VALUE: (characterId: string) => `input[name="characters.${characterId}.overrideCurrencyValue"]`,
+  CALCULATED_XP_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .calculated-xp-label`,
+  CALCULATED_CURRENCY_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .calculated-currency-label`,
+  EARNED_INCOME_LABEL: (characterId: string) => `.member-activity[data-character-id="${characterId}"] .earned-income-label`,
 } as const;
 
 /**
@@ -53,6 +60,8 @@ export const CHARACTER_FIELD_PATTERNS = {
   TASK_LEVEL_ALL: 'select[name$=".taskLevel"]',
   SUCCESS_LEVEL_ALL: 'select[name$=".successLevel"]',
   PROFICIENCY_RANK_ALL: 'select[name$=".proficiencyRank"]',
+  OVERRIDE_XP_ALL: 'input[name$=".overrideXp"]',
+  OVERRIDE_CURRENCY_ALL: 'input[name$=".overrideCurrency"]',
 } as const;
 
 /**
@@ -103,4 +112,5 @@ export const CSS_CLASSES = {
   CHRONICLE_PATH_VISIBLE: 'chronicle-path-visible',
   COLLAPSIBLE_SECTION: 'collapsible-section',
   COLLAPSED: 'collapsed',
+  STRIKETHROUGH_OVERRIDE: 'strikethrough-override',
 } as const;

--- a/scripts/handlers/chronicle-generation.ts
+++ b/scripts/handlers/chronicle-generation.ts
@@ -189,7 +189,11 @@ function extractUniqueFields(rawCharacters: Record<string, Partial<UniqueFields>
     earnedIncome: Number(uniqueFields.earnedIncome) || 0,
     currencySpent: Number(uniqueFields.currencySpent) || 0,
     notes: uniqueFields.notes || '',
-    consumeReplay: Boolean(uniqueFields.consumeReplay)
+    consumeReplay: Boolean(uniqueFields.consumeReplay),
+    overrideXp: Boolean(uniqueFields.overrideXp),
+    overrideXpValue: Number(uniqueFields.overrideXpValue) || 0,
+    overrideCurrency: Boolean(uniqueFields.overrideCurrency),
+    overrideCurrencyValue: Number(uniqueFields.overrideCurrencyValue) || 0
   };
 }
 

--- a/scripts/handlers/collapsible-section-handlers.ts
+++ b/scripts/handlers/collapsible-section-handlers.ts
@@ -50,12 +50,15 @@ const SECTIONS_WITH_SUMMARY = [
 
 /**
  * Type guard that checks if a string is a valid collapsible section ID.
+ * 
+ * Accepts both static section IDs from VALID_SECTION_IDS and dynamic
+ * per-character Advanced section IDs matching the `advanced-{characterId}` pattern.
  *
  * @param id - The string to check
- * @returns True if the string is a member of VALID_SECTION_IDS
+ * @returns True if the string is a valid section ID
  */
-export function isValidSectionId(id: string): id is typeof VALID_SECTION_IDS[number] {
-  return (VALID_SECTION_IDS as readonly string[]).includes(id);
+export function isValidSectionId(id: string): boolean {
+  return (VALID_SECTION_IDS as readonly string[]).includes(id) || id.startsWith('advanced-');
 }
 
 /**
@@ -278,6 +281,27 @@ export function updateAllSectionSummaries(container: HTMLElement): void {
 }
 
 /**
+ * Applies a collapse state to a section element and its header.
+ * 
+ * @param section - The section element to apply the state to
+ * @param header - The header element within the section
+ * @param isCollapsed - Whether the section should be collapsed
+ */
+function applyCollapseState(
+  section: HTMLElement,
+  header: HTMLElement,
+  isCollapsed: boolean
+): void {
+  if (isCollapsed) {
+    section.classList.add('collapsed');
+    header.setAttribute('aria-expanded', 'false');
+  } else {
+    section.classList.remove('collapsed');
+    header.setAttribute('aria-expanded', 'true');
+  }
+}
+
+/**
  * Initializes collapse states from storage when form is rendered.
  * 
  * Loads saved collapse states from localStorage and applies them to all sections.
@@ -289,9 +313,8 @@ export function updateAllSectionSummaries(container: HTMLElement): void {
  * Requirements: collapsible-shared-sections 1.9, 2.11, 3.9, 4.6, 5.6
  */
 export function initializeCollapseSections(container: HTMLElement): void {
-  // Initialize collapse state for each section
+  // Initialize collapse state for each static section
   for (const sectionId of VALID_SECTION_IDS) {
-    // Find section element
     const section = container.querySelector(
       `.collapsible-section[data-section-id="${sectionId}"]`
     ) as HTMLElement;
@@ -300,26 +323,36 @@ export function initializeCollapseSections(container: HTMLElement): void {
       continue;
     }
     
-    // Find header element
     const header = section.querySelector('.collapsible-header') as HTMLElement;
-    
     if (!header) {
       warn(`Missing header for section: "${sectionId}"`);
       continue;
     }
     
-    // Load collapse state from storage or use default
     const savedState = loadCollapseState(sectionId);
     const isCollapsed = savedState ?? getDefaultCollapseState(sectionId);
-    
-    // Apply collapse state to DOM
-    if (isCollapsed) {
-      section.classList.add('collapsed');
-      header.setAttribute('aria-expanded', 'false');
-    } else {
-      section.classList.remove('collapsed');
-      header.setAttribute('aria-expanded', 'true');
+    applyCollapseState(section, header, isCollapsed);
+  }
+  
+  // Initialize dynamic Advanced sections (default: collapsed)
+  const advancedSections = container.querySelectorAll<HTMLElement>(
+    '.collapsible-section[data-section-id^="advanced-"]'
+  );
+  for (const section of advancedSections) {
+    const sectionId = section.dataset.sectionId;
+    if (!sectionId) {
+      continue;
     }
+
+    const header = section.querySelector('.collapsible-header') as HTMLElement;
+    if (!header) {
+      warn(`Missing header for section: "${sectionId}"`);
+      continue;
+    }
+
+    const savedState = loadCollapseState(sectionId);
+    const isCollapsed = savedState ?? true;
+    applyCollapseState(section, header, isCollapsed);
   }
   
   // Initialize summary text for sections with summaries

--- a/scripts/handlers/event-listener-helpers.ts
+++ b/scripts/handlers/event-listener-helpers.ts
@@ -38,6 +38,10 @@ import {
     handleGmCharacterDrop,
     handleGmCharacterClear
 } from './gm-character-handlers.js';
+import {
+    handleOverrideXpChange,
+    handleOverrideCurrencyChange
+} from './override-handlers.js';
 import { createEarnedIncomeChangeHandler } from '../utils/earned-income-form-helpers.js';
 import { clearPartyChronicleData, savePartyChronicleData } from '../model/party-chronicle-storage.js';
 import { PartyChronicleData, UniqueFields } from '../model/party-chronicle-types.js';
@@ -609,6 +613,43 @@ export function attachCollapsibleSectionListeners(container: HTMLElement): void 
         });
         header.addEventListener('keydown', (event: Event) => {
             handleSectionHeaderKeydown(event as KeyboardEvent, container);
+        });
+    });
+}
+
+/**
+ * Attaches override checkbox change event listeners for XP and currency overrides.
+ * 
+ * Queries all override XP and currency checkboxes, extracts the character ID
+ * from each checkbox's name attribute, and attaches change listeners that
+ * delegate to the appropriate override handler.
+ * 
+ * @param container - Form container element
+ * 
+ * Requirements: gm-override-values 1.4, 1.5, 3.3, 3.4, 4.5, 4.6
+ */
+export function attachOverrideListeners(container: HTMLElement): void {
+    const xpCheckboxes = container.querySelectorAll<HTMLInputElement>(
+        CHARACTER_FIELD_PATTERNS.OVERRIDE_XP_ALL
+    );
+    xpCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener('change', () => {
+            const match = checkbox.name.match(/characters\.([^.]+)\.overrideXp/);
+            if (match) {
+                handleOverrideXpChange(match[1], container);
+            }
+        });
+    });
+
+    const currencyCheckboxes = container.querySelectorAll<HTMLInputElement>(
+        CHARACTER_FIELD_PATTERNS.OVERRIDE_CURRENCY_ALL
+    );
+    currencyCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener('change', () => {
+            const match = checkbox.name.match(/characters\.([^.]+)\.overrideCurrency/);
+            if (match) {
+                handleOverrideCurrencyChange(match[1], container);
+            }
         });
     });
 }

--- a/scripts/handlers/event-listener-helpers.ts
+++ b/scripts/handlers/event-listener-helpers.ts
@@ -409,7 +409,11 @@ function buildDefaultCharacterFields(partyActors: PartyActor[]): { [actorId: str
                 earnedIncome: 0,
                 currencySpent: 0,
                 notes: '',
-                consumeReplay: false
+                consumeReplay: false,
+                overrideXp: false,
+                overrideXpValue: 0,
+                overrideCurrency: false,
+                overrideCurrencyValue: 0
             };
         }
     });

--- a/scripts/handlers/form-data-extraction.ts
+++ b/scripts/handlers/form-data-extraction.ts
@@ -113,6 +113,11 @@ export function extractFormData(container: HTMLElement, partyActors: PartyActor[
             notes: (container.querySelector(`#notes-${actorId}`) as HTMLTextAreaElement)?.value || '',
             // Read session reporting fields
             consumeReplay: (container.querySelector(`input[name="characters.${actorId}.consumeReplay"]`) as HTMLInputElement)?.checked || false,
+            // Read override fields (gm-override-values 6.1, 6.2)
+            overrideXp: (container.querySelector(`input[name="characters.${actorId}.overrideXp"]`) as HTMLInputElement)?.checked || false,
+            overrideXpValue: Number.parseFloat((container.querySelector(`input[name="characters.${actorId}.overrideXpValue"]`) as HTMLInputElement)?.value) || 0,
+            overrideCurrency: (container.querySelector(`input[name="characters.${actorId}.overrideCurrency"]`) as HTMLInputElement)?.checked || false,
+            overrideCurrencyValue: Number.parseFloat((container.querySelector(`input[name="characters.${actorId}.overrideCurrencyValue"]`) as HTMLInputElement)?.value) || 0,
         };
     });
     

--- a/scripts/handlers/gm-character-handlers.ts
+++ b/scripts/handlers/gm-character-handlers.ts
@@ -135,7 +135,11 @@ function buildDefaultUniqueFields(
     earnedIncome: 0,
     currencySpent: 0,
     notes: 'GM Credit',
-    consumeReplay: false
+    consumeReplay: false,
+    overrideXp: false,
+    overrideXpValue: 0,
+    overrideCurrency: false,
+    overrideCurrencyValue: 0
   };
 }
 

--- a/scripts/handlers/override-handlers.ts
+++ b/scripts/handlers/override-handlers.ts
@@ -64,8 +64,8 @@ export function handleOverrideXpChange(
  * Handles the Override Currency checkbox change for a specific character.
  * 
  * When checked: enables the Override Currency input and adds strikethrough to both
- * the Calculated Currency Label and the Earned Income Label. When unchecked: disables
- * the input and removes strikethrough from both labels.
+ * the Calculated Currency Label and the Earned Income Value. When unchecked: disables
+ * the input and removes strikethrough from both.
  * 
  * @param characterId - The actor ID of the character
  * @param container - HTMLElement wrapping the form container
@@ -85,8 +85,8 @@ export function handleOverrideCurrencyChange(
   const calculatedLabel = container.querySelector<HTMLElement>(
     CHARACTER_FIELD_SELECTORS.CALCULATED_CURRENCY_LABEL(characterId)
   );
-  const earnedIncomeLabel = container.querySelector<HTMLElement>(
-    CHARACTER_FIELD_SELECTORS.EARNED_INCOME_LABEL(characterId)
+  const earnedIncomeValue = container.querySelector<HTMLElement>(
+    CHARACTER_FIELD_SELECTORS.EARNED_INCOME_VALUE(characterId)
   );
 
   if (!checkbox || !input) {
@@ -98,14 +98,14 @@ export function handleOverrideCurrencyChange(
 
   input.disabled = !isChecked;
 
-  const labels = [calculatedLabel, earnedIncomeLabel].filter(
+  const elements = [calculatedLabel, earnedIncomeValue].filter(
     (el): el is HTMLElement => el !== null
   );
-  for (const label of labels) {
+  for (const element of elements) {
     if (isChecked) {
-      label.classList.add(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
+      element.classList.add(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
     } else {
-      label.classList.remove(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
+      element.classList.remove(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
     }
   }
 

--- a/scripts/handlers/override-handlers.ts
+++ b/scripts/handlers/override-handlers.ts
@@ -1,0 +1,161 @@
+/**
+ * Override Handlers
+ * 
+ * Event handlers for XP and currency override checkboxes in the Advanced section
+ * of each character card. Manages the toggle logic for enabling/disabling override
+ * inputs and applying/removing strikethrough styling on calculated labels.
+ * 
+ * Requirements: gm-override-values 3.3, 3.4, 3.5, 3.6, 4.5, 4.6, 4.7, 4.8, 6.2
+ */
+
+import {
+  CHARACTER_FIELD_SELECTORS,
+  CHARACTER_FIELD_PATTERNS,
+  CSS_CLASSES
+} from '../constants/dom-selectors.js';
+import { debug } from '../utils/logger.js';
+
+/**
+ * Handles the Override XP checkbox change for a specific character.
+ * 
+ * When checked: enables the Override XP input and adds strikethrough to the
+ * Calculated XP Label. When unchecked: disables the input and removes strikethrough.
+ * 
+ * @param characterId - The actor ID of the character
+ * @param container - HTMLElement wrapping the form container
+ * 
+ * Requirements: gm-override-values 3.3, 3.4, 3.5, 3.6
+ */
+export function handleOverrideXpChange(
+  characterId: string,
+  container: HTMLElement
+): void {
+  const checkbox = container.querySelector<HTMLInputElement>(
+    CHARACTER_FIELD_SELECTORS.OVERRIDE_XP(characterId)
+  );
+  const input = container.querySelector<HTMLInputElement>(
+    CHARACTER_FIELD_SELECTORS.OVERRIDE_XP_VALUE(characterId)
+  );
+  const calculatedLabel = container.querySelector<HTMLElement>(
+    CHARACTER_FIELD_SELECTORS.CALCULATED_XP_LABEL(characterId)
+  );
+
+  if (!checkbox || !input) {
+    debug(`Override XP elements not found for character: ${characterId}`);
+    return;
+  }
+
+  const isChecked = checkbox.checked;
+
+  input.disabled = !isChecked;
+
+  if (calculatedLabel) {
+    if (isChecked) {
+      calculatedLabel.classList.add(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
+    } else {
+      calculatedLabel.classList.remove(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
+    }
+  }
+
+  debug(`Override XP ${isChecked ? 'enabled' : 'disabled'} for character: ${characterId}`);
+}
+
+/**
+ * Handles the Override Currency checkbox change for a specific character.
+ * 
+ * When checked: enables the Override Currency input and adds strikethrough to both
+ * the Calculated Currency Label and the Earned Income Label. When unchecked: disables
+ * the input and removes strikethrough from both labels.
+ * 
+ * @param characterId - The actor ID of the character
+ * @param container - HTMLElement wrapping the form container
+ * 
+ * Requirements: gm-override-values 4.5, 4.6, 4.7, 4.8
+ */
+export function handleOverrideCurrencyChange(
+  characterId: string,
+  container: HTMLElement
+): void {
+  const checkbox = container.querySelector<HTMLInputElement>(
+    CHARACTER_FIELD_SELECTORS.OVERRIDE_CURRENCY(characterId)
+  );
+  const input = container.querySelector<HTMLInputElement>(
+    CHARACTER_FIELD_SELECTORS.OVERRIDE_CURRENCY_VALUE(characterId)
+  );
+  const calculatedLabel = container.querySelector<HTMLElement>(
+    CHARACTER_FIELD_SELECTORS.CALCULATED_CURRENCY_LABEL(characterId)
+  );
+  const earnedIncomeLabel = container.querySelector<HTMLElement>(
+    CHARACTER_FIELD_SELECTORS.EARNED_INCOME_LABEL(characterId)
+  );
+
+  if (!checkbox || !input) {
+    debug(`Override Currency elements not found for character: ${characterId}`);
+    return;
+  }
+
+  const isChecked = checkbox.checked;
+
+  input.disabled = !isChecked;
+
+  const labels = [calculatedLabel, earnedIncomeLabel].filter(
+    (el): el is HTMLElement => el !== null
+  );
+  for (const label of labels) {
+    if (isChecked) {
+      label.classList.add(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
+    } else {
+      label.classList.remove(CSS_CLASSES.STRIKETHROUGH_OVERRIDE);
+    }
+  }
+
+  debug(`Override Currency ${isChecked ? 'enabled' : 'disabled'} for character: ${characterId}`);
+}
+
+/**
+ * Initializes override states from saved data on form load.
+ * 
+ * Reads all override checkboxes in the container and applies the correct
+ * disabled/enabled and strikethrough states based on their checked state.
+ * Called during form initialization after template rendering.
+ * 
+ * @param container - HTMLElement wrapping the form container
+ * 
+ * Requirements: gm-override-values 6.2
+ */
+export function initializeOverrideStates(container: HTMLElement): void {
+  // Initialize XP override states
+  const xpCheckboxes = container.querySelectorAll<HTMLInputElement>(
+    CHARACTER_FIELD_PATTERNS.OVERRIDE_XP_ALL
+  );
+  for (const checkbox of xpCheckboxes) {
+    const characterId = extractCharacterIdFromName(checkbox.name);
+    if (characterId) {
+      handleOverrideXpChange(characterId, container);
+    }
+  }
+
+  // Initialize Currency override states
+  const currencyCheckboxes = container.querySelectorAll<HTMLInputElement>(
+    CHARACTER_FIELD_PATTERNS.OVERRIDE_CURRENCY_ALL
+  );
+  for (const checkbox of currencyCheckboxes) {
+    const characterId = extractCharacterIdFromName(checkbox.name);
+    if (characterId) {
+      handleOverrideCurrencyChange(characterId, container);
+    }
+  }
+
+  debug('Initialized override states from saved data');
+}
+
+/**
+ * Extracts the character ID from a form field name attribute.
+ * 
+ * @param name - The name attribute value (e.g., "characters.actor-123.overrideXp")
+ * @returns The character ID, or null if the name doesn't match the expected pattern
+ */
+function extractCharacterIdFromName(name: string): string | null {
+  const match = /^characters\.([^.]+)\./.exec(name);
+  return match ? match[1] : null;
+}

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -39,8 +39,10 @@ import {
     attachPortraitListeners,
     attachFilePickerListener,
     attachCollapsibleSectionListeners,
-    attachGmCharacterListeners
+    attachGmCharacterListeners,
+    attachOverrideListeners
 } from './handlers/event-listener-helpers.js';
+import { initializeOverrideStates } from './handlers/override-handlers.js';
 
 /** Registers world-scoped Foundry settings shown in the module config. */
 function registerSettings(): void {
@@ -563,6 +565,9 @@ function attachEventListeners(
     // Collapsible section listeners
     attachCollapsibleSectionListeners(container);
     
+    // Override checkbox listeners (XP and currency overrides)
+    attachOverrideListeners(container);
+    
     // GM character drop zone and clear button listeners
     attachGmCharacterListeners(container, partyActors, partySheet);
 }
@@ -619,6 +624,10 @@ async function initializeForm(
     // Initialize collapsible sections
     initializeCollapseSections(container);
     updateAllSectionSummaries(container);
+    
+    // Initialize override states from saved data
+    // Requirements: gm-override-values 6.2
+    initializeOverrideStates(container);
     
     // Initial validation display and button state
     updateValidationDisplay(container, partyActors, extractFormData);

--- a/scripts/model/party-chronicle-mapper.ts
+++ b/scripts/model/party-chronicle-mapper.ts
@@ -128,6 +128,10 @@ export function mapToCharacterData(
   // Calculate reputation using the reputation calculator
   const reputationLines = calculateReputation(shared, actor);
   
+  // Apply override values when active (gm-override-values 5.1, 5.2, 5.3, 5.4)
+  const xpGained = unique.overrideXp === true ? unique.overrideXpValue : shared.xpEarned;
+  const finalCurrencyGained = unique.overrideCurrency === true ? unique.overrideCurrencyValue : currencyGained;
+
   const chronicleData: ChronicleData = {
     // Character identification from unique fields
     char: unique.characterName,
@@ -142,13 +146,13 @@ export function mapToCharacterData(
     eventcode: shared.eventCode,
     date: shared.eventDate,
     
-    // XP from shared fields
-    xp_gained: shared.xpEarned,
+    // XP - uses override value when active, otherwise shared xpEarned
+    xp_gained: xpGained,
     
-    // Character-specific rewards - calculated values
+    // Character-specific rewards - calculated values (currency uses override when active)
     income_earned: incomeEarned,
     treasure_bundle_value: treasureBundleValue,
-    currency_gained: currencyGained,
+    currency_gained: finalCurrencyGained,
     currency_spent: unique.currencySpent,
     
     // Character-specific notes from unique fields

--- a/scripts/model/party-chronicle-types.ts
+++ b/scripts/model/party-chronicle-types.ts
@@ -121,6 +121,18 @@ export interface UniqueFields {
 
   /** Whether the player is consuming a replay for this session (paizo-session-reporting 10.2, 3.2) */
   consumeReplay: boolean;
+
+  /** Whether the XP override is active for this character (gm-override-values 3.1, 3.2, 4.1, 4.4, 8.1, 8.2) */
+  overrideXp: boolean;
+
+  /** Override XP value (used when overrideXp is true) (gm-override-values 3.1, 3.2, 4.1, 4.4, 8.1, 8.2) */
+  overrideXpValue: number;
+
+  /** Whether the currency override is active for this character (gm-override-values 3.1, 3.2, 4.1, 4.4, 8.1, 8.2) */
+  overrideCurrency: boolean;
+
+  /** Override currency value (used when overrideCurrency is true) (gm-override-values 3.1, 3.2, 4.1, 4.4, 8.1, 8.2) */
+  overrideCurrencyValue: number;
 }
 
 /**

--- a/scripts/model/session-report-builder.ts
+++ b/scripts/model/session-report-builder.ts
@@ -13,6 +13,8 @@ import type { SharedFields, UniqueFields } from './party-chronicle-types.js';
 import { buildScenarioIdentifier } from './scenario-identifier.js';
 import type { BonusRep, SessionReport, SignUp } from './session-report-types.js';
 import { getGameSystem } from '../utils/game-system-detector.js';
+import { calculateTreasureBundleValue, calculateCurrencyGained, getCreditsAwarded } from '../utils/treasure-bundle-calculator.js';
+import { calculateEarnedIncome } from '../utils/earned-income-calculator.js';
 
 /**
  * Minimal actor shape required by the session report builder.
@@ -53,22 +55,62 @@ export interface SessionReportBuildParams {
 }
 
 /**
+ * Calculates XP and currency values for a character, applying overrides when active.
+ *
+ * @param shared - Shared fields for calculated defaults
+ * @param characterFields - Per-character unique fields with override flags
+ * @returns Object with xpEarned and currencyGained values
+ *
+ * Requirements: gm-override-values 7.1, 7.2, 7.3
+ */
+function calculateCharacterRewards(
+  shared: SharedFields,
+  characterFields: UniqueFields
+): { xpEarned: number; currencyGained: number } {
+  const gameSystem = getGameSystem();
+
+  const xpEarned = characterFields.overrideXp === true
+    ? characterFields.overrideXpValue
+    : shared.xpEarned;
+
+  let currencyGained: number;
+  if (characterFields.overrideCurrency === true) {
+    currencyGained = characterFields.overrideCurrencyValue;
+  } else {
+    const incomeEarned = calculateEarnedIncome(
+      characterFields.taskLevel,
+      characterFields.successLevel,
+      characterFields.proficiencyRank,
+      shared.downtimeDays,
+      gameSystem
+    );
+    const treasureBundleValue = gameSystem === 'sf2e'
+      ? getCreditsAwarded(characterFields.level)
+      : calculateTreasureBundleValue(shared.treasureBundles, characterFields.level);
+    currencyGained = calculateCurrencyGained(treasureBundleValue, incomeEarned, gameSystem);
+  }
+
+  return { xpEarned, currencyGained };
+}
+
+/**
  * Builds a SignUp entry for a single party member.
  *
  * @param actor - Party actor with PFS data
- * @param characterFields - Per-character unique fields (name, consumeReplay)
- * @param chosenFactionReputation - Shared reputation value for the chosen faction
+ * @param characterFields - Per-character unique fields (name, consumeReplay, overrides)
+ * @param shared - Shared fields for calculated defaults and override logic
  * @returns A SignUp entry for the session report
  *
- * Requirements: paizo-session-reporting 4.9, 4.10
+ * Requirements: paizo-session-reporting 4.9, 4.10, gm-override-values 7.1, 7.2, 7.3
  */
 function buildSignUp(
   actor: SessionReportActor,
   characterFields: UniqueFields,
-  chosenFactionReputation: number
+  shared: SharedFields
 ): SignUp {
   const currentFaction = actor.system?.pfs?.currentFaction ?? '';
   const factionFullName = FACTION_NAMES[currentFaction] ?? currentFaction;
+  const rewards = calculateCharacterRewards(shared, characterFields);
 
   return {
     isGM: false,
@@ -76,8 +118,10 @@ function buildSignUp(
     characterNumber: actor.system?.pfs?.characterNumber ?? 0,
     characterName: characterFields.characterName,
     consumeReplay: characterFields.consumeReplay,
-    repEarned: chosenFactionReputation,
+    repEarned: shared.chosenFactionReputation,
     faction: factionFullName,
+    xpEarned: rewards.xpEarned,
+    currencyGained: rewards.currencyGained,
   };
 }
 
@@ -85,19 +129,20 @@ function buildSignUp(
  * Builds a SignUp entry for the GM character with `isGM: true`.
  *
  * @param actor - GM character actor with PFS data
- * @param characterFields - GM character's unique fields (name, consumeReplay)
- * @param chosenFactionReputation - Shared reputation value for the chosen faction
+ * @param characterFields - GM character's unique fields (name, consumeReplay, overrides)
+ * @param shared - Shared fields for calculated defaults and override logic
  * @returns A SignUp entry with isGM set to true
  *
- * Requirements: gm-character-party-sheet 6.1, 6.2, 6.3
+ * Requirements: gm-character-party-sheet 6.1, 6.2, 6.3, gm-override-values 7.1, 7.2, 7.3
  */
 function buildGmSignUp(
   actor: SessionReportActor,
   characterFields: UniqueFields,
-  chosenFactionReputation: number
+  shared: SharedFields
 ): SignUp {
   const currentFaction = actor.system?.pfs?.currentFaction ?? '';
   const factionFullName = FACTION_NAMES[currentFaction] ?? currentFaction;
+  const rewards = calculateCharacterRewards(shared, characterFields);
 
   return {
     isGM: true,
@@ -105,8 +150,10 @@ function buildGmSignUp(
     characterNumber: actor.system?.pfs?.characterNumber ?? 0,
     characterName: characterFields.characterName,
     consumeReplay: characterFields.consumeReplay,
-    repEarned: chosenFactionReputation,
+    repEarned: shared.chosenFactionReputation,
     faction: factionFullName,
+    xpEarned: rewards.xpEarned,
+    currencyGained: rewards.currencyGained,
   };
 }
 
@@ -191,10 +238,10 @@ export function buildSessionReport(params: SessionReportBuildParams): SessionRep
 
   const signUps = partyActors
     .filter((actor) => characters[actor.id] !== undefined)
-    .map((actor) => buildSignUp(actor, characters[actor.id], shared.chosenFactionReputation));
+    .map((actor) => buildSignUp(actor, characters[actor.id], shared));
 
   if (gmCharacterActor && gmCharacterFields) {
-    signUps.push(buildGmSignUp(gmCharacterActor, gmCharacterFields, shared.chosenFactionReputation));
+    signUps.push(buildGmSignUp(gmCharacterActor, gmCharacterFields, shared));
   }
 
   return {

--- a/scripts/model/session-report-types.ts
+++ b/scripts/model/session-report-types.ts
@@ -36,6 +36,12 @@ export interface SignUp {
 
   /** Full faction name from actor.system.pfs.currentFaction */
   faction: string;
+
+  /** XP earned for this character (override value when active, shared xpEarned otherwise) */
+  xpEarned: number;
+
+  /** Currency gained for this character (override value when active, calculated otherwise) */
+  currencyGained: number;
 }
 
 /**

--- a/templates/party-chronicle-filling.hbs
+++ b/templates/party-chronicle-filling.hbs
@@ -431,7 +431,7 @@
                                 <label class="checkbox-label">
                                     <input type="checkbox" name="characters.{{gmCharacter.id}}.overrideCurrency"
                                         {{#if (lookup gmCharacterFields 'overrideCurrency')}}checked{{/if}}>
-                                    {{#if (eq gameSystem "sf2e")}}Override Credits Gained{{else}}Override GP Gained{{/if}}
+                                    {{#if (eq gameSystem "sf2e")}}Override Credits{{else}}Override GP Gained{{/if}}
                                 </label>
                                 <input type="number" name="characters.{{gmCharacter.id}}.overrideCurrencyValue"
                                        value="{{#if gmCharacterFields}}{{lookup gmCharacterFields 'overrideCurrencyValue'}}{{else}}0{{/if}}"
@@ -574,7 +574,7 @@
                                 <label class="checkbox-label">
                                     <input type="checkbox" name="characters.{{this.id}}.overrideCurrency"
                                         {{#if (lookup (lookup ../savedData.characters this.id) 'overrideCurrency')}}checked{{/if}}>
-                                    {{#if (eq ../gameSystem "sf2e")}}Override Credits Gained{{else}}Override GP Gained{{/if}}
+                                    {{#if (eq ../gameSystem "sf2e")}}Override Credits{{else}}Override GP Gained{{/if}}
                                 </label>
                                 <input type="number" name="characters.{{this.id}}.overrideCurrencyValue"
                                        value="{{#if (lookup ../savedData.characters this.id)}}{{lookup (lookup ../savedData.characters this.id) 'overrideCurrencyValue'}}{{else}}0{{/if}}"

--- a/templates/party-chronicle-filling.hbs
+++ b/templates/party-chronicle-filling.hbs
@@ -365,22 +365,28 @@
                         </div>
 
                         <div class="form-group">
-                            <label><i class="fas fa-coins"></i> Earned Income</label>
+                            <label class="earned-income-label"><i class="fas fa-coins"></i> Earned Income</label>
                             <div class="earned-income-value" data-tooltip="Calculated from Task Level, Success Level, Proficiency Rank, and Downtime Days.">{{getZeroCurrencyDisplay gameSystem}}</div>
                             <input type="hidden" name="characters.{{gmCharacter.id}}.earnedIncome" value="0" class="earned-income-hidden">
                         </div>
+                    </div>
+
+                    {{!-- XP Earned display --}}
+                    <div class="form-group">
+                        <label><i class="fas fa-star"></i> XP Earned</label>
+                        <div class="calculated-xp-label">{{shared.xpEarned}} XP</div>
                     </div>
 
                     {{!-- Treasure Bundle Value / Credits Awarded display --}}
                     {{#if (eq gameSystem "sf2e")}}
                     <div class="form-group">
                         <label><i class="fas fa-coins"></i> Credits Awarded</label>
-                        <div class="credits-awarded-value">{{getCreditsAwarded gmCharacter.level}} Credits</div>
+                        <div class="credits-awarded-value calculated-currency-label">{{getCreditsAwarded gmCharacter.level}} Credits</div>
                     </div>
                     {{else}}
                     <div class="form-group">
                         <label><i class="fas fa-treasure-chest"></i> Treasure Bundles</label>
-                        <div class="treasure-bundle-value" data-tooltip="Calculated from shared Treasure Bundles field. Each TB is worth {{getTreasureBundleValue gmCharacter.level}} gp at level {{gmCharacter.level}}.">0.00 gp</div>
+                        <div class="treasure-bundle-value calculated-currency-label" data-tooltip="Calculated from shared Treasure Bundles field. Each TB is worth {{getTreasureBundleValue gmCharacter.level}} gp at level {{gmCharacter.level}}.">0.00 gp</div>
                     </div>
                     {{/if}}
 
@@ -394,12 +400,44 @@
                         <textarea id="notes-{{gmCharacter.id}}" name="characters.{{gmCharacter.id}}.notes" rows="3">{{#if gmCharacterFields}}{{lookup gmCharacterFields 'notes'}}{{/if}}</textarea>
                     </div>
 
-                    <div class="form-group">
-                        <label class="checkbox-label" data-tooltip="Check this if the player has already played this scenario and is using a replay credit. This is included in the session report for paizo.com.">
-                            <input type="checkbox" name="characters.{{gmCharacter.id}}.consumeReplay"
-                                {{#if (lookup gmCharacterFields 'consumeReplay')}}checked{{/if}}>
-                            Consume Replay
-                        </label>
+                    {{!-- Advanced Section (collapsible) --}}
+                    <div class="collapsible-section advanced-section" data-section-id="advanced-{{gmCharacter.id}}">
+                        <header class="collapsible-header" role="button" tabindex="0"
+                                aria-expanded="false" aria-controls="advanced-content-{{gmCharacter.id}}">
+                            <span class="chevron"></span>
+                            <span class="section-title">Advanced</span>
+                        </header>
+                        <div class="collapsible-content" id="advanced-content-{{gmCharacter.id}}">
+                            <div class="form-group">
+                                <label class="checkbox-label" data-tooltip="Check this if the player has already played this scenario and is using a replay credit. This is included in the session report for paizo.com.">
+                                    <input type="checkbox" name="characters.{{gmCharacter.id}}.consumeReplay"
+                                        {{#if (lookup gmCharacterFields 'consumeReplay')}}checked{{/if}}>
+                                    Consume Replay
+                                </label>
+                            </div>
+
+                            <div class="form-group override-group">
+                                <label class="checkbox-label">
+                                    <input type="checkbox" name="characters.{{gmCharacter.id}}.overrideXp"
+                                        {{#if (lookup gmCharacterFields 'overrideXp')}}checked{{/if}}>
+                                    Override XP
+                                </label>
+                                <input type="number" name="characters.{{gmCharacter.id}}.overrideXpValue"
+                                       value="{{#if gmCharacterFields}}{{lookup gmCharacterFields 'overrideXpValue'}}{{else}}0{{/if}}"
+                                       min="0" step="1" disabled>
+                            </div>
+
+                            <div class="form-group override-group">
+                                <label class="checkbox-label">
+                                    <input type="checkbox" name="characters.{{gmCharacter.id}}.overrideCurrency"
+                                        {{#if (lookup gmCharacterFields 'overrideCurrency')}}checked{{/if}}>
+                                    {{#if (eq gameSystem "sf2e")}}Override Credits Gained{{else}}Override GP Gained{{/if}}
+                                </label>
+                                <input type="number" name="characters.{{gmCharacter.id}}.overrideCurrencyValue"
+                                       value="{{#if gmCharacterFields}}{{lookup gmCharacterFields 'overrideCurrencyValue'}}{{else}}0{{/if}}"
+                                       min="0" {{#if (eq gameSystem "sf2e")}}step="1"{{else}}step="0.01"{{/if}} disabled>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -470,22 +508,28 @@
                         </div>
                         
                         <div class="form-group">
-                            <label><i class="fas fa-coins"></i> Earned Income</label>
+                            <label class="earned-income-label"><i class="fas fa-coins"></i> Earned Income</label>
                             <div class="earned-income-value" data-tooltip="Calculated from Task Level, Success Level, Proficiency Rank, and Downtime Days.">{{getZeroCurrencyDisplay ../gameSystem}}</div>
                             <input type="hidden" name="characters.{{this.id}}.earnedIncome" value="0" class="earned-income-hidden">
                         </div>
                     </div>
                     
+                    {{!-- XP Earned display --}}
+                    <div class="form-group">
+                        <label><i class="fas fa-star"></i> XP Earned</label>
+                        <div class="calculated-xp-label">{{../shared.xpEarned}} XP</div>
+                    </div>
+
                     {{!-- Treasure Bundle Value / Credits Awarded display --}}
                     {{#if (eq ../gameSystem "sf2e")}}
                     <div class="form-group">
                         <label><i class="fas fa-coins"></i> Credits Awarded</label>
-                        <div class="credits-awarded-value">{{getCreditsAwarded this.level}} Credits</div>
+                        <div class="credits-awarded-value calculated-currency-label">{{getCreditsAwarded this.level}} Credits</div>
                     </div>
                     {{else}}
                     <div class="form-group">
                         <label><i class="fas fa-treasure-chest"></i> Treasure Bundles</label>
-                        <div class="treasure-bundle-value" data-tooltip="Calculated from shared Treasure Bundles field. Each TB is worth {{getTreasureBundleValue this.level}} gp at level {{this.level}}.">0.00 gp</div>
+                        <div class="treasure-bundle-value calculated-currency-label" data-tooltip="Calculated from shared Treasure Bundles field. Each TB is worth {{getTreasureBundleValue this.level}} gp at level {{this.level}}.">0.00 gp</div>
                     </div>
                     {{/if}}
                     
@@ -499,12 +543,44 @@
                         <textarea id="notes-{{this.id}}" name="characters.{{this.id}}.notes" rows="3">{{#if (lookup ../savedData.characters this.id)}}{{lookup (lookup ../savedData.characters this.id) 'notes'}}{{/if}}</textarea>
                     </div>
                     
-                    <div class="form-group">
-                        <label class="checkbox-label" data-tooltip="Check this if the player has already played this scenario and is using a replay credit. This is included in the session report for paizo.com.">
-                            <input type="checkbox" name="characters.{{this.id}}.consumeReplay"
-                                {{#if (lookup (lookup ../savedData.characters this.id) 'consumeReplay')}}checked{{/if}}>
-                            Consume Replay
-                        </label>
+                    {{!-- Advanced Section (collapsible) --}}
+                    <div class="collapsible-section advanced-section" data-section-id="advanced-{{this.id}}">
+                        <header class="collapsible-header" role="button" tabindex="0"
+                                aria-expanded="false" aria-controls="advanced-content-{{this.id}}">
+                            <span class="chevron"></span>
+                            <span class="section-title">Advanced</span>
+                        </header>
+                        <div class="collapsible-content" id="advanced-content-{{this.id}}">
+                            <div class="form-group">
+                                <label class="checkbox-label" data-tooltip="Check this if the player has already played this scenario and is using a replay credit. This is included in the session report for paizo.com.">
+                                    <input type="checkbox" name="characters.{{this.id}}.consumeReplay"
+                                        {{#if (lookup (lookup ../savedData.characters this.id) 'consumeReplay')}}checked{{/if}}>
+                                    Consume Replay
+                                </label>
+                            </div>
+
+                            <div class="form-group override-group">
+                                <label class="checkbox-label">
+                                    <input type="checkbox" name="characters.{{this.id}}.overrideXp"
+                                        {{#if (lookup (lookup ../savedData.characters this.id) 'overrideXp')}}checked{{/if}}>
+                                    Override XP
+                                </label>
+                                <input type="number" name="characters.{{this.id}}.overrideXpValue"
+                                       value="{{#if (lookup ../savedData.characters this.id)}}{{lookup (lookup ../savedData.characters this.id) 'overrideXpValue'}}{{else}}0{{/if}}"
+                                       min="0" step="1" disabled>
+                            </div>
+
+                            <div class="form-group override-group">
+                                <label class="checkbox-label">
+                                    <input type="checkbox" name="characters.{{this.id}}.overrideCurrency"
+                                        {{#if (lookup (lookup ../savedData.characters this.id) 'overrideCurrency')}}checked{{/if}}>
+                                    {{#if (eq ../gameSystem "sf2e")}}Override Credits Gained{{else}}Override GP Gained{{/if}}
+                                </label>
+                                <input type="number" name="characters.{{this.id}}.overrideCurrencyValue"
+                                       value="{{#if (lookup ../savedData.characters this.id)}}{{lookup (lookup ../savedData.characters this.id) 'overrideCurrencyValue'}}{{else}}0{{/if}}"
+                                       min="0" {{#if (eq ../gameSystem "sf2e")}}step="1"{{else}}step="0.01"{{/if}} disabled>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </section>

--- a/tests/PartyChronicleApp.property.test.ts
+++ b/tests/PartyChronicleApp.property.test.ts
@@ -101,6 +101,10 @@ const uniqueFieldsArbitrary: fc.Arbitrary<UniqueFields> = fc.record({
   currencySpent: fc.integer({ min: 0, max: 9999 }),
   notes: fc.string({ maxLength: 50 }),
   consumeReplay: fc.boolean(),
+  overrideXp: fc.boolean(),
+  overrideXpValue: fc.integer({ min: 0, max: 100 }),
+  overrideCurrency: fc.boolean(),
+  overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
 });
 
 /**

--- a/tests/clear-button-scenario-preservation.pbt.test.ts
+++ b/tests/clear-button-scenario-preservation.pbt.test.ts
@@ -197,7 +197,11 @@ describe('Clear Button Scenario Preservation Bug Condition Exploration', () => {
                   earnedIncome: 50,
                   currencySpent: 10,
                   notes: 'Test notes',
-                  consumeReplay: false
+                  consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0
                 }
               }
             };
@@ -259,7 +263,11 @@ describe('Clear Button Scenario Preservation Bug Condition Exploration', () => {
                   earnedIncome: 0,
                   currencySpent: 0,
                   notes: '',
-                  consumeReplay: false
+                  consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0
                 }
               }
             };

--- a/tests/clear-button-visibility-update.pbt.test.ts
+++ b/tests/clear-button-visibility-update.pbt.test.ts
@@ -207,7 +207,11 @@ describe('Clear Button Chronicle Path Visibility Bug Condition Exploration', () 
                   earnedIncome: 50,
                   currencySpent: 10,
                   notes: 'Test notes',
-                  consumeReplay: false
+                  consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0
                 }
               }
             };
@@ -276,7 +280,11 @@ describe('Clear Button Chronicle Path Visibility Bug Condition Exploration', () 
                   earnedIncome: 0,
                   currencySpent: 0,
                   notes: '',
-                  consumeReplay: false
+                  consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0
                 }
               }
             };

--- a/tests/earned-income-persistence.property.test.ts
+++ b/tests/earned-income-persistence.property.test.ts
@@ -103,6 +103,10 @@ describe('Earned Income Data Persistence - Property Tests', () => {
       currencySpent: fc.double({ min: 0, max: 1000, noNaN: true }),
       notes: fc.string({ maxLength: 200 }),
       consumeReplay: fc.boolean(),
+      overrideXp: fc.boolean(),
+      overrideXpValue: fc.integer({ min: 0, max: 100 }),
+      overrideCurrency: fc.boolean(),
+      overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
     });
 
     /**
@@ -182,6 +186,10 @@ describe('Earned Income Data Persistence - Property Tests', () => {
                   currencySpent: 0,
                   notes: '',
                   consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0,
                 },
               },
             };
@@ -476,6 +484,10 @@ describe('Earned Income Data Persistence - Property Tests', () => {
                   currencySpent: 0,
                   notes: '',
                   consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0,
                 },
               },
             };
@@ -577,6 +589,10 @@ describe('Earned Income Data Persistence - Property Tests', () => {
                   currencySpent: 0,
                   notes: '',
                   consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0,
                 },
               },
             };

--- a/tests/handlers/chronicle-path-persistence.property.test.ts
+++ b/tests/handlers/chronicle-path-persistence.property.test.ts
@@ -197,7 +197,11 @@ describe('Chronicle Path Persistence Property Tests', () => {
           earnedIncome: 10.5,
           currencySpent: 5.0,
           notes: 'Test notes 1',
-          consumeReplay: false
+          consumeReplay: false,
+          overrideXp: false,
+          overrideXpValue: 0,
+          overrideCurrency: false,
+          overrideCurrencyValue: 0
         },
         actor2: {
           characterName: 'Character 2',
@@ -209,7 +213,11 @@ describe('Chronicle Path Persistence Property Tests', () => {
           earnedIncome: 8.0,
           currencySpent: 3.5,
           notes: 'Test notes 2',
-          consumeReplay: false
+          consumeReplay: false,
+          overrideXp: false,
+          overrideXpValue: 0,
+          overrideCurrency: false,
+          overrideCurrencyValue: 0
         }
       }
     };

--- a/tests/handlers/collapsible-section-handlers.test.ts
+++ b/tests/handlers/collapsible-section-handlers.test.ts
@@ -12,7 +12,8 @@ import {
   toggleSectionCollapse,
   updateSectionSummary,
   updateAllSectionSummaries,
-  initializeCollapseSections
+  initializeCollapseSections,
+  isValidSectionId
 } from '../../scripts/handlers/collapsible-section-handlers';
 
 // Mock the storage module
@@ -426,6 +427,104 @@ describe('collapsible-section-handlers', () => {
 
       // adventure-summary defaults to NOT collapsed, so collapsed class should be removed
       expect(section.classList.contains('collapsed')).toBe(false);
+      expect(header.getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  describe('isValidSectionId', () => {
+    it('should accept static section IDs', () => {
+      expect(isValidSectionId('event-details')).toBe(true);
+      expect(isValidSectionId('reputation')).toBe(true);
+      expect(isValidSectionId('shared-rewards')).toBe(true);
+      expect(isValidSectionId('adventure-summary')).toBe(true);
+      expect(isValidSectionId('items-to-strike-out')).toBe(true);
+    });
+
+    it('should accept advanced-{characterId} patterns', () => {
+      expect(isValidSectionId('advanced-actor-123')).toBe(true);
+      expect(isValidSectionId('advanced-abc')).toBe(true);
+      expect(isValidSectionId('advanced-gm-char-456')).toBe(true);
+    });
+
+    it('should reject invalid section IDs', () => {
+      expect(isValidSectionId('invalid-section')).toBe(false);
+      expect(isValidSectionId('')).toBe(false);
+      expect(isValidSectionId('advancedactor-123')).toBe(false);
+    });
+  });
+
+  describe('initializeCollapseSections with Advanced sections', () => {
+    it('should initialize Advanced sections as collapsed by default', () => {
+      const advancedSection = document.createElement('div');
+      advancedSection.className = 'collapsible-section advanced-section';
+      advancedSection.setAttribute('data-section-id', 'advanced-actor-1');
+      const header = document.createElement('header');
+      header.className = 'collapsible-header';
+      header.setAttribute('aria-expanded', 'true');
+      advancedSection.appendChild(header);
+      container.appendChild(advancedSection);
+
+      initializeCollapseSections(container);
+
+      expect(advancedSection.classList.contains('collapsed')).toBe(true);
+      expect(header.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should initialize multiple Advanced sections independently', () => {
+      const section1 = document.createElement('div');
+      section1.className = 'collapsible-section advanced-section';
+      section1.setAttribute('data-section-id', 'advanced-actor-1');
+      const header1 = document.createElement('header');
+      header1.className = 'collapsible-header';
+      section1.appendChild(header1);
+      container.appendChild(section1);
+
+      const section2 = document.createElement('div');
+      section2.className = 'collapsible-section advanced-section';
+      section2.setAttribute('data-section-id', 'advanced-actor-2');
+      const header2 = document.createElement('header');
+      header2.className = 'collapsible-header';
+      section2.appendChild(header2);
+      container.appendChild(section2);
+
+      initializeCollapseSections(container);
+
+      expect(section1.classList.contains('collapsed')).toBe(true);
+      expect(header1.getAttribute('aria-expanded')).toBe('false');
+      expect(section2.classList.contains('collapsed')).toBe(true);
+      expect(header2.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should warn when Advanced section header is missing', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const sectionNoHeader = document.createElement('div');
+      sectionNoHeader.className = 'collapsible-section advanced-section';
+      sectionNoHeader.setAttribute('data-section-id', 'advanced-actor-1');
+      container.appendChild(sectionNoHeader);
+
+      initializeCollapseSections(container);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[PFS Chronicle]',
+        'Missing header for section: "advanced-actor-1"'
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should allow toggling an Advanced section', () => {
+      const advancedSection = document.createElement('div');
+      advancedSection.className = 'collapsible-section advanced-section collapsed';
+      advancedSection.setAttribute('data-section-id', 'advanced-actor-1');
+      const header = document.createElement('header');
+      header.className = 'collapsible-header';
+      header.setAttribute('aria-expanded', 'false');
+      advancedSection.appendChild(header);
+      container.appendChild(advancedSection);
+
+      toggleSectionCollapse('advanced-actor-1', container);
+
+      expect(advancedSection.classList.contains('collapsed')).toBe(false);
       expect(header.getAttribute('aria-expanded')).toBe('true');
     });
   });

--- a/tests/handlers/event-listener-helpers.test.ts
+++ b/tests/handlers/event-listener-helpers.test.ts
@@ -8,7 +8,7 @@
  * @jest-environment jsdom
  */
 
-import { attachClearButtonListener, PartyActor } from '../../scripts/handlers/event-listener-helpers';
+import { attachClearButtonListener, attachOverrideListeners, attachCollapsibleSectionListeners, PartyActor } from '../../scripts/handlers/event-listener-helpers';
 
 // Track calls to clearPartyChronicleData and savePartyChronicleData
 const mockClearPartyChronicleData = jest.fn().mockResolvedValue(undefined);
@@ -45,6 +45,13 @@ jest.mock('../../scripts/handlers/collapsible-section-handlers', () => ({
 
 jest.mock('../../scripts/utils/earned-income-form-helpers', () => ({
   createEarnedIncomeChangeHandler: jest.fn(() => jest.fn()),
+}));
+
+const mockHandleOverrideXpChange = jest.fn();
+const mockHandleOverrideCurrencyChange = jest.fn();
+jest.mock('../../scripts/handlers/override-handlers', () => ({
+  handleOverrideXpChange: (...args: unknown[]) => mockHandleOverrideXpChange(...args),
+  handleOverrideCurrencyChange: (...args: unknown[]) => mockHandleOverrideCurrencyChange(...args),
 }));
 
 jest.mock('../../scripts/handlers/session-report-handler', () => ({
@@ -254,6 +261,63 @@ describe('event-listener-helpers', () => {
 
       expect(mockClearPartyChronicleData).not.toHaveBeenCalled();
       expect(mockSavePartyChronicleData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attachOverrideListeners', () => {
+    it('attaches change listeners to XP override checkboxes that call handleOverrideXpChange', () => {
+      container.innerHTML = `
+        <input type="checkbox" name="characters.actor-1.overrideXp">
+        <input type="checkbox" name="characters.actor-2.overrideXp">
+      `;
+
+      attachOverrideListeners(container);
+
+      const checkboxes = container.querySelectorAll<HTMLInputElement>('input[name$=".overrideXp"]');
+      checkboxes[0].dispatchEvent(new Event('change'));
+
+      expect(mockHandleOverrideXpChange).toHaveBeenCalledWith('actor-1', container);
+    });
+
+    it('attaches change listeners to currency override checkboxes that call handleOverrideCurrencyChange', () => {
+      container.innerHTML = `
+        <input type="checkbox" name="characters.actor-1.overrideCurrency">
+      `;
+
+      attachOverrideListeners(container);
+
+      const checkbox = container.querySelector<HTMLInputElement>('input[name$=".overrideCurrency"]')!;
+      checkbox.dispatchEvent(new Event('change'));
+
+      expect(mockHandleOverrideCurrencyChange).toHaveBeenCalledWith('actor-1', container);
+    });
+
+    it('handles empty container with no override checkboxes', () => {
+      container.innerHTML = '';
+
+      expect(() => attachOverrideListeners(container)).not.toThrow();
+      expect(mockHandleOverrideXpChange).not.toHaveBeenCalled();
+      expect(mockHandleOverrideCurrencyChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attachCollapsibleSectionListeners', () => {
+    it('attaches click and keydown listeners to collapsible section headers', () => {
+      container.innerHTML = `
+        <div class="collapsible-section" data-section-id="event-details">
+          <header class="collapsible-header" role="button" tabindex="0">
+            <span class="section-title">Event Details</span>
+          </header>
+        </div>
+      `;
+
+      attachCollapsibleSectionListeners(container);
+
+      const header = container.querySelector('.collapsible-header') as HTMLElement;
+      header.click();
+
+      const { handleSectionHeaderClick } = require('../../scripts/handlers/collapsible-section-handlers');
+      expect(handleSectionHeaderClick).toHaveBeenCalled();
     });
   });
 });

--- a/tests/handlers/gm-character-handlers.property.test.ts
+++ b/tests/handlers/gm-character-handlers.property.test.ts
@@ -114,6 +114,10 @@ const uniqueFieldsArbitrary: fc.Arbitrary<UniqueFields> = fc.record({
   currencySpent: fc.integer({ min: 0, max: 9999 }),
   notes: fc.string({ maxLength: 50 }),
   consumeReplay: fc.boolean(),
+  overrideXp: fc.boolean(),
+  overrideXpValue: fc.integer({ min: 0, max: 100 }),
+  overrideCurrency: fc.boolean(),
+  overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
 });
 
 /**

--- a/tests/handlers/gm-character-handlers.test.ts
+++ b/tests/handlers/gm-character-handlers.test.ts
@@ -238,6 +238,10 @@ describe('handleGmCharacterDrop', () => {
           currencySpent: 0,
           notes: '',
           consumeReplay: false,
+          overrideXp: false,
+          overrideXpValue: 0,
+          overrideCurrency: false,
+          overrideCurrencyValue: 0,
         },
       },
     });
@@ -299,6 +303,10 @@ describe('handleGmCharacterClear', () => {
           currencySpent: 10,
           notes: 'GM credit',
           consumeReplay: false,
+          overrideXp: false,
+          overrideXpValue: 0,
+          overrideCurrency: false,
+          overrideCurrencyValue: 0,
         },
         'party-member-1': {
           characterName: 'Valeros',
@@ -312,6 +320,10 @@ describe('handleGmCharacterClear', () => {
           currencySpent: 0,
           notes: '',
           consumeReplay: false,
+          overrideXp: false,
+          overrideXpValue: 0,
+          overrideCurrency: false,
+          overrideCurrencyValue: 0,
         },
       },
     });

--- a/tests/handlers/override-handlers.test.ts
+++ b/tests/handlers/override-handlers.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for override handlers
+ * 
+ * Tests the event handlers for XP and currency override checkboxes,
+ * including toggle logic, strikethrough styling, and initialization.
+ * 
+ * Requirements: gm-override-values 3.3, 3.4, 3.5, 3.6, 4.5, 4.6, 4.7, 4.8, 6.2, 8.1, 8.2
+ * 
+ * @jest-environment jsdom
+ */
+
+import {
+  handleOverrideXpChange,
+  handleOverrideCurrencyChange,
+  initializeOverrideStates
+} from '../../scripts/handlers/override-handlers';
+
+// Mock the logger to suppress debug output during tests
+jest.mock('../../scripts/utils/logger', () => ({
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}));
+
+/**
+ * Creates a mock character card DOM structure with override elements.
+ * 
+ * @param characterId - The character's actor ID
+ * @param options - Configuration for the initial state of override elements
+ * @returns An HTMLElement containing the character card structure
+ */
+function createCharacterCard(
+  characterId: string,
+  options: {
+    xpChecked?: boolean;
+    currencyChecked?: boolean;
+    xpValue?: number;
+    currencyValue?: number;
+  } = {}
+): HTMLElement {
+  const card = document.createElement('div');
+  card.className = 'member-activity';
+  card.setAttribute('data-character-id', characterId);
+
+  card.innerHTML = `
+    <div class="calculated-xp-label">4 XP</div>
+    <div class="calculated-currency-label">25.5 GP</div>
+    <div class="earned-income-label">Earned Income</div>
+    <input type="checkbox" name="characters.${characterId}.overrideXp"
+           ${options.xpChecked ? 'checked' : ''}>
+    <input type="number" name="characters.${characterId}.overrideXpValue"
+           value="${options.xpValue ?? 0}" disabled>
+    <input type="checkbox" name="characters.${characterId}.overrideCurrency"
+           ${options.currencyChecked ? 'checked' : ''}>
+    <input type="number" name="characters.${characterId}.overrideCurrencyValue"
+           value="${options.currencyValue ?? 0}" disabled>
+  `;
+
+  return card;
+}
+
+describe('override-handlers', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  describe('handleOverrideXpChange', () => {
+    it('enables input and adds strikethrough when checkbox is checked', () => {
+      const card = createCharacterCard('actor-1', { xpChecked: true });
+      container.appendChild(card);
+
+      handleOverrideXpChange('actor-1', container);
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideXpValue"]'
+      );
+      const label = container.querySelector('.calculated-xp-label');
+
+      expect(input!.disabled).toBe(false);
+      expect(label!.classList.contains('strikethrough-override')).toBe(true);
+    });
+
+    it('disables input and removes strikethrough when checkbox is unchecked', () => {
+      const card = createCharacterCard('actor-1', { xpChecked: false });
+      container.appendChild(card);
+
+      // First add strikethrough to verify it gets removed
+      const label = container.querySelector('.calculated-xp-label')!;
+      label.classList.add('strikethrough-override');
+
+      handleOverrideXpChange('actor-1', container);
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideXpValue"]'
+      );
+
+      expect(input!.disabled).toBe(true);
+      expect(label.classList.contains('strikethrough-override')).toBe(false);
+    });
+
+    it('handles missing elements gracefully', () => {
+      // Empty container — no elements to find
+      expect(() => handleOverrideXpChange('nonexistent', container)).not.toThrow();
+    });
+  });
+
+  describe('handleOverrideCurrencyChange', () => {
+    it('enables input and adds strikethrough to currency label AND earned income label when checked', () => {
+      const card = createCharacterCard('actor-1', { currencyChecked: true });
+      container.appendChild(card);
+
+      handleOverrideCurrencyChange('actor-1', container);
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideCurrencyValue"]'
+      );
+      const currencyLabel = container.querySelector('.calculated-currency-label');
+      const earnedIncomeLabel = container.querySelector('.earned-income-label');
+
+      expect(input!.disabled).toBe(false);
+      expect(currencyLabel!.classList.contains('strikethrough-override')).toBe(true);
+      expect(earnedIncomeLabel!.classList.contains('strikethrough-override')).toBe(true);
+    });
+
+    it('disables input and removes strikethrough when checkbox is unchecked', () => {
+      const card = createCharacterCard('actor-1', { currencyChecked: false });
+      container.appendChild(card);
+
+      // First add strikethrough to verify it gets removed
+      const currencyLabel = container.querySelector('.calculated-currency-label')!;
+      const earnedIncomeLabel = container.querySelector('.earned-income-label')!;
+      currencyLabel.classList.add('strikethrough-override');
+      earnedIncomeLabel.classList.add('strikethrough-override');
+
+      handleOverrideCurrencyChange('actor-1', container);
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideCurrencyValue"]'
+      );
+
+      expect(input!.disabled).toBe(true);
+      expect(currencyLabel.classList.contains('strikethrough-override')).toBe(false);
+      expect(earnedIncomeLabel.classList.contains('strikethrough-override')).toBe(false);
+    });
+
+    it('handles missing elements gracefully', () => {
+      expect(() => handleOverrideCurrencyChange('nonexistent', container)).not.toThrow();
+    });
+  });
+
+  describe('initializeOverrideStates', () => {
+    it('applies correct states from saved data when overrides are checked', () => {
+      const card = createCharacterCard('actor-1', {
+        xpChecked: true,
+        currencyChecked: true
+      });
+      container.appendChild(card);
+
+      initializeOverrideStates(container);
+
+      const xpInput = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideXpValue"]'
+      );
+      const currencyInput = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideCurrencyValue"]'
+      );
+      const xpLabel = container.querySelector('.calculated-xp-label');
+      const currencyLabel = container.querySelector('.calculated-currency-label');
+      const earnedIncomeLabel = container.querySelector('.earned-income-label');
+
+      expect(xpInput!.disabled).toBe(false);
+      expect(currencyInput!.disabled).toBe(false);
+      expect(xpLabel!.classList.contains('strikethrough-override')).toBe(true);
+      expect(currencyLabel!.classList.contains('strikethrough-override')).toBe(true);
+      expect(earnedIncomeLabel!.classList.contains('strikethrough-override')).toBe(true);
+    });
+
+    it('applies correct states from saved data when overrides are unchecked', () => {
+      const card = createCharacterCard('actor-1', {
+        xpChecked: false,
+        currencyChecked: false
+      });
+      container.appendChild(card);
+
+      initializeOverrideStates(container);
+
+      const xpInput = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideXpValue"]'
+      );
+      const currencyInput = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideCurrencyValue"]'
+      );
+      const xpLabel = container.querySelector('.calculated-xp-label');
+      const currencyLabel = container.querySelector('.calculated-currency-label');
+
+      expect(xpInput!.disabled).toBe(true);
+      expect(currencyInput!.disabled).toBe(true);
+      expect(xpLabel!.classList.contains('strikethrough-override')).toBe(false);
+      expect(currencyLabel!.classList.contains('strikethrough-override')).toBe(false);
+    });
+
+    it('handles empty container gracefully', () => {
+      expect(() => initializeOverrideStates(container)).not.toThrow();
+    });
+  });
+
+  describe('per-character independence', () => {
+    it('override controls are independent per character', () => {
+      const card1 = createCharacterCard('actor-1', {
+        xpChecked: true,
+        currencyChecked: false
+      });
+      const card2 = createCharacterCard('actor-2', {
+        xpChecked: false,
+        currencyChecked: true
+      });
+      container.appendChild(card1);
+      container.appendChild(card2);
+
+      initializeOverrideStates(container);
+
+      // Actor 1: XP override enabled, currency override disabled
+      const xpInput1 = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideXpValue"]'
+      );
+      const currencyInput1 = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-1.overrideCurrencyValue"]'
+      );
+      const xpLabel1 = card1.querySelector('.calculated-xp-label');
+      const currencyLabel1 = card1.querySelector('.calculated-currency-label');
+
+      expect(xpInput1!.disabled).toBe(false);
+      expect(currencyInput1!.disabled).toBe(true);
+      expect(xpLabel1!.classList.contains('strikethrough-override')).toBe(true);
+      expect(currencyLabel1!.classList.contains('strikethrough-override')).toBe(false);
+
+      // Actor 2: XP override disabled, currency override enabled
+      const xpInput2 = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-2.overrideXpValue"]'
+      );
+      const currencyInput2 = container.querySelector<HTMLInputElement>(
+        'input[name="characters.actor-2.overrideCurrencyValue"]'
+      );
+      const xpLabel2 = card2.querySelector('.calculated-xp-label');
+      const currencyLabel2 = card2.querySelector('.calculated-currency-label');
+
+      expect(xpInput2!.disabled).toBe(true);
+      expect(currencyInput2!.disabled).toBe(false);
+      expect(xpLabel2!.classList.contains('strikethrough-override')).toBe(false);
+      expect(currencyLabel2!.classList.contains('strikethrough-override')).toBe(true);
+    });
+  });
+});

--- a/tests/handlers/override-handlers.test.ts
+++ b/tests/handlers/override-handlers.test.ts
@@ -45,7 +45,7 @@ function createCharacterCard(
   card.innerHTML = `
     <div class="calculated-xp-label">4 XP</div>
     <div class="calculated-currency-label">25.5 GP</div>
-    <div class="earned-income-label">Earned Income</div>
+    <div class="earned-income-value">0.00 gp</div>
     <input type="checkbox" name="characters.${characterId}.overrideXp"
            ${options.xpChecked ? 'checked' : ''}>
     <input type="number" name="characters.${characterId}.overrideXpValue"
@@ -107,7 +107,7 @@ describe('override-handlers', () => {
   });
 
   describe('handleOverrideCurrencyChange', () => {
-    it('enables input and adds strikethrough to currency label AND earned income label when checked', () => {
+    it('enables input and adds strikethrough to currency label AND earned income value when checked', () => {
       const card = createCharacterCard('actor-1', { currencyChecked: true });
       container.appendChild(card);
 
@@ -117,11 +117,11 @@ describe('override-handlers', () => {
         'input[name="characters.actor-1.overrideCurrencyValue"]'
       );
       const currencyLabel = container.querySelector('.calculated-currency-label');
-      const earnedIncomeLabel = container.querySelector('.earned-income-label');
+      const earnedIncomeValue = container.querySelector('.earned-income-value');
 
       expect(input!.disabled).toBe(false);
       expect(currencyLabel!.classList.contains('strikethrough-override')).toBe(true);
-      expect(earnedIncomeLabel!.classList.contains('strikethrough-override')).toBe(true);
+      expect(earnedIncomeValue!.classList.contains('strikethrough-override')).toBe(true);
     });
 
     it('disables input and removes strikethrough when checkbox is unchecked', () => {
@@ -130,9 +130,9 @@ describe('override-handlers', () => {
 
       // First add strikethrough to verify it gets removed
       const currencyLabel = container.querySelector('.calculated-currency-label')!;
-      const earnedIncomeLabel = container.querySelector('.earned-income-label')!;
+      const earnedIncomeValue = container.querySelector('.earned-income-value')!;
       currencyLabel.classList.add('strikethrough-override');
-      earnedIncomeLabel.classList.add('strikethrough-override');
+      earnedIncomeValue.classList.add('strikethrough-override');
 
       handleOverrideCurrencyChange('actor-1', container);
 
@@ -142,7 +142,7 @@ describe('override-handlers', () => {
 
       expect(input!.disabled).toBe(true);
       expect(currencyLabel.classList.contains('strikethrough-override')).toBe(false);
-      expect(earnedIncomeLabel.classList.contains('strikethrough-override')).toBe(false);
+      expect(earnedIncomeValue.classList.contains('strikethrough-override')).toBe(false);
     });
 
     it('handles missing elements gracefully', () => {
@@ -168,13 +168,13 @@ describe('override-handlers', () => {
       );
       const xpLabel = container.querySelector('.calculated-xp-label');
       const currencyLabel = container.querySelector('.calculated-currency-label');
-      const earnedIncomeLabel = container.querySelector('.earned-income-label');
+      const earnedIncomeValue = container.querySelector('.earned-income-value');
 
       expect(xpInput!.disabled).toBe(false);
       expect(currencyInput!.disabled).toBe(false);
       expect(xpLabel!.classList.contains('strikethrough-override')).toBe(true);
       expect(currencyLabel!.classList.contains('strikethrough-override')).toBe(true);
-      expect(earnedIncomeLabel!.classList.contains('strikethrough-override')).toBe(true);
+      expect(earnedIncomeValue!.classList.contains('strikethrough-override')).toBe(true);
     });
 
     it('applies correct states from saved data when overrides are unchecked', () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -140,6 +140,11 @@ jest.mock('../scripts/handlers/event-listener-helpers', () => ({
   attachFilePickerListener: jest.fn(),
   attachCollapsibleSectionListeners: jest.fn(),
   attachGmCharacterListeners: jest.fn(),
+  attachOverrideListeners: jest.fn(),
+}));
+
+jest.mock('../scripts/handlers/override-handlers', () => ({
+  initializeOverrideStates: jest.fn(),
 }));
 
 // Suppress console noise
@@ -155,7 +160,9 @@ import {
   attachFormFieldListeners,
   attachSaveButtonListener,
   attachGenerateButtonListener,
+  attachOverrideListeners,
 } from '../scripts/handlers/event-listener-helpers';
+import { initializeOverrideStates } from '../scripts/handlers/override-handlers';
 import { updateValidationDisplay } from '../scripts/handlers/validation-display';
 import {
   updateAllTreasureBundleDisplays,
@@ -333,6 +340,7 @@ describe('main.ts', () => {
       expect(attachFormFieldListeners).toHaveBeenCalledWith(container, partyActors);
       expect(attachSaveButtonListener).toHaveBeenCalledWith(container, partyActors);
       expect(attachGenerateButtonListener).toHaveBeenCalledWith(container, partyActors, undefined);
+      expect(attachOverrideListeners).toHaveBeenCalledWith(container);
     });
 
     it('initializes form state after rendering', async () => {
@@ -343,6 +351,7 @@ describe('main.ts', () => {
       expect(updateAllEarnedIncomeDisplays).toHaveBeenCalled();
       expect(initializeCollapseSections).toHaveBeenCalledWith(container);
       expect(updateAllSectionSummaries).toHaveBeenCalledWith(container);
+      expect(initializeOverrideStates).toHaveBeenCalledWith(container);
       expect(updateValidationDisplay).toHaveBeenCalled();
     });
 

--- a/tests/model/__tests__/session-report-encoding-fix.pbt.test.ts
+++ b/tests/model/__tests__/session-report-encoding-fix.pbt.test.ts
@@ -90,6 +90,10 @@ const buildParamsArbitrary = sharedFieldsArbitrary.chain((shared) =>
           currencySpent: 0,
           notes: '',
           consumeReplay: char.consumeReplay,
+          overrideXp: false,
+          overrideXpValue: 0,
+          overrideCurrency: false,
+          overrideCurrencyValue: 0,
         },
       },
       partyActors: [

--- a/tests/model/party-chronicle-mapper.test.ts
+++ b/tests/model/party-chronicle-mapper.test.ts
@@ -783,7 +783,9 @@ describe('Property 6: Data Combination Correctness', () => {
         expect(result.event).toBe(shared.scenarioName);
         expect(result.eventcode).toBe(shared.eventCode);
         expect(result.date).toBe(shared.eventDate);
-        expect(result.xp_gained).toBe(shared.xpEarned);
+        // xp_gained uses override when active (gm-override-values 5.1, 5.3)
+        const expectedXp = unique.overrideXp ? unique.overrideXpValue : shared.xpEarned;
+        expect(result.xp_gained).toBe(expectedXp);
         expect(result.summary_checkbox).toEqual(shared.adventureSummaryCheckboxes);
         expect(result.strikeout_item_lines).toEqual(shared.strikeoutItems);
         expect(result.treasure_bundles).toBe(shared.treasureBundles.toString());
@@ -801,7 +803,10 @@ describe('Property 6: Data Combination Correctness', () => {
         expect(typeof result.income_earned).toBe('number');
         expect(typeof result.treasure_bundle_value).toBe('number');
         expect(typeof result.currency_gained).toBe('number');
-        expect(result.currency_gained).toBeGreaterThanOrEqual(0);
+        // currency_gained can be the override value (which may be any non-negative double)
+        if (!unique.overrideCurrency) {
+          expect(result.currency_gained).toBeGreaterThanOrEqual(0);
+        }
       }),
       { numRuns: 100 }
     );
@@ -874,7 +879,9 @@ describe('Property 6: Data Combination Correctness', () => {
         expect(result.treasure_bundles).toStrictEqual(shared.treasureBundles.toString());
 
         // Numeric fields should be identical
-        expect(result.xp_gained).toStrictEqual(shared.xpEarned);
+        // xp_gained uses override when active (gm-override-values 5.1, 5.3)
+        const expectedXp = unique.overrideXp ? unique.overrideXpValue : shared.xpEarned;
+        expect(result.xp_gained).toStrictEqual(expectedXp);
         expect(result.level).toStrictEqual(unique.level);
         expect(result.currency_spent).toStrictEqual(unique.currencySpent);
         
@@ -957,8 +964,13 @@ describe('Property 6: Data Combination Correctness', () => {
         expect(result.treasure_bundle_value).toBe(0);
         // With task level "-", income_earned should be 0
         expect(result.income_earned).toBe(0);
-        // gp_gained should be 0 when both are 0
-        expect(result.currency_gained).toBe(0);
+        // currency_gained depends on override state (gm-override-values 5.2, 5.4)
+        if (unique.overrideCurrency) {
+          expect(result.currency_gained).toBe(unique.overrideCurrencyValue);
+        } else {
+          // gp_gained should be 0 when both treasure bundles and income are 0
+          expect(result.currency_gained).toBe(0);
+        }
       }),
       { numRuns: 100 }
     );
@@ -1018,7 +1030,9 @@ describe('Property 6: Data Combination Correctness', () => {
         const result = mapToCharacterData(shared, unique, mockActor);
 
         // Verify zero values are preserved (not treated as falsy)
-        expect(result.xp_gained).toBe(0);
+        // xp_gained uses override when active (gm-override-values 5.1, 5.3)
+        const expectedXp = unique.overrideXp ? unique.overrideXpValue : 0;
+        expect(result.xp_gained).toBe(expectedXp);
         expect(result.income_earned).toBe(0);
         expect(result.currency_spent).toBe(0);
         
@@ -1103,5 +1117,206 @@ describe('Property 6: Data Combination Correctness', () => {
       }),
       { numRuns: 100 }
     );
+  });
+});
+
+/**
+ * Override-aware mapToCharacterData tests.
+ *
+ * Validates that XP and currency overrides replace calculated values
+ * when active, and that calculated values are used when overrides are inactive.
+ *
+ * Requirements: gm-override-values 5.1, 5.2, 5.3, 5.4
+ */
+describe('mapToCharacterData - Override-aware values', () => {
+  beforeAll(() => {
+    (globalThis as any).game = { system: { id: 'pf2e' }, modules: new Map() };
+  });
+
+  afterAll(() => {
+    delete (globalThis as any).game;
+  });
+
+  const createMockActor = (actorId: string, currentFaction: string | null = null) => ({
+    id: actorId,
+    system: { pfs: { currentFaction } }
+  }) as unknown as PartyActor;
+
+  const createSharedFields = (overrides: Partial<SharedFields> = {}): SharedFields => ({
+    gmPfsNumber: '12345',
+    scenarioName: 'Test Scenario',
+    eventCode: 'TEST-001',
+    eventDate: '2024-01-15',
+    xpEarned: 4,
+    adventureSummaryCheckboxes: [],
+    strikeoutItems: [],
+    treasureBundles: 2,
+    layoutId: 'layout-1',
+    seasonId: 'season-5',
+    blankChroniclePath: '/path/to/chronicle.pdf',
+    chosenFactionReputation: 0,
+    reputationValues: { EA: 0, GA: 0, HH: 0, VS: 0, RO: 0, VW: 0 },
+    downtimeDays: 4,
+    reportingA: false,
+    reportingB: false,
+    reportingC: false,
+    reportingD: false,
+    ...overrides
+  });
+
+  const createUniqueFields = (overrides: Partial<UniqueFields> = {}): UniqueFields => ({
+    characterName: 'Test Character',
+    playerNumber: '12345',
+    characterNumber: '01',
+    level: 5,
+    taskLevel: 3,
+    successLevel: 'success',
+    proficiencyRank: 'trained',
+    earnedIncome: 0,
+    currencySpent: 0,
+    notes: '',
+    consumeReplay: false,
+    overrideXp: false,
+    overrideXpValue: 0,
+    overrideCurrency: false,
+    overrideCurrencyValue: 0,
+    ...overrides
+  });
+
+  /**
+   * Requirements: gm-override-values 5.1
+   */
+  it('should use overrideXpValue when overrideXp is true', () => {
+    const shared = createSharedFields({ xpEarned: 4 });
+    const unique = createUniqueFields({
+      overrideXp: true,
+      overrideXpValue: 2,
+      taskLevel: '-'
+    });
+    const actor = createMockActor('actor-1', null);
+
+    const result = mapToCharacterData(shared, unique, actor);
+
+    expect(result.xp_gained).toBe(2);
+  });
+
+  /**
+   * Requirements: gm-override-values 5.1 — zero is a valid override value
+   */
+  it('should use overrideXpValue of zero when overrideXp is true', () => {
+    const shared = createSharedFields({ xpEarned: 4 });
+    const unique = createUniqueFields({
+      overrideXp: true,
+      overrideXpValue: 0,
+      taskLevel: '-'
+    });
+    const actor = createMockActor('actor-1', null);
+
+    const result = mapToCharacterData(shared, unique, actor);
+
+    expect(result.xp_gained).toBe(0);
+  });
+
+  /**
+   * Requirements: gm-override-values 5.3
+   */
+  it('should use shared.xpEarned when overrideXp is false', () => {
+    const shared = createSharedFields({ xpEarned: 4 });
+    const unique = createUniqueFields({
+      overrideXp: false,
+      overrideXpValue: 99,
+      taskLevel: '-'
+    });
+    const actor = createMockActor('actor-1', null);
+
+    const result = mapToCharacterData(shared, unique, actor);
+
+    expect(result.xp_gained).toBe(4);
+  });
+
+  /**
+   * Requirements: gm-override-values 5.2
+   */
+  it('should use overrideCurrencyValue when overrideCurrency is true', () => {
+    const shared = createSharedFields({ treasureBundles: 2, downtimeDays: 4 });
+    const unique = createUniqueFields({
+      overrideCurrency: true,
+      overrideCurrencyValue: 150.5,
+      level: 5,
+      taskLevel: 3,
+      successLevel: 'success',
+      proficiencyRank: 'trained'
+    });
+    const actor = createMockActor('actor-1', null);
+
+    const result = mapToCharacterData(shared, unique, actor);
+
+    expect(result.currency_gained).toBe(150.5);
+  });
+
+  /**
+   * Requirements: gm-override-values 5.2 — zero is a valid override value
+   */
+  it('should use overrideCurrencyValue of zero when overrideCurrency is true', () => {
+    const shared = createSharedFields({ treasureBundles: 2, downtimeDays: 4 });
+    const unique = createUniqueFields({
+      overrideCurrency: true,
+      overrideCurrencyValue: 0,
+      level: 5,
+      taskLevel: 3,
+      successLevel: 'success',
+      proficiencyRank: 'trained'
+    });
+    const actor = createMockActor('actor-1', null);
+
+    const result = mapToCharacterData(shared, unique, actor);
+
+    expect(result.currency_gained).toBe(0);
+  });
+
+  /**
+   * Requirements: gm-override-values 5.4
+   */
+  it('should use calculated currency_gained when overrideCurrency is false', () => {
+    const shared = createSharedFields({ treasureBundles: 2, downtimeDays: 4 });
+    const unique = createUniqueFields({
+      overrideCurrency: false,
+      overrideCurrencyValue: 999,
+      level: 5,
+      taskLevel: 3,
+      successLevel: 'success',
+      proficiencyRank: 'trained'
+    });
+    const actor = createMockActor('actor-1', null);
+
+    const result = mapToCharacterData(shared, unique, actor);
+
+    // Level 5: 2 × 10 = 20 (treasure bundles)
+    // Level 3 trained success: 0.5 gp/day × 4 days = 2 gp (earned income)
+    // Total: 20 + 2 = 22
+    expect(result.currency_gained).toBe(22);
+  });
+
+  /**
+   * Requirements: gm-override-values 5.1, 5.2
+   */
+  it('should apply both XP and currency overrides simultaneously', () => {
+    const shared = createSharedFields({ xpEarned: 4, treasureBundles: 2, downtimeDays: 4 });
+    const unique = createUniqueFields({
+      overrideXp: true,
+      overrideXpValue: 8,
+      overrideCurrency: true,
+      overrideCurrencyValue: 250,
+      level: 5,
+      taskLevel: 3,
+      successLevel: 'success',
+      proficiencyRank: 'trained'
+    });
+    const actor = createMockActor('actor-1', null);
+
+    const result = mapToCharacterData(shared, unique, actor);
+
+    expect(result.xp_gained).toBe(8);
+    expect(result.currency_gained).toBe(250);
   });
 });

--- a/tests/model/party-chronicle-mapper.test.ts
+++ b/tests/model/party-chronicle-mapper.test.ts
@@ -60,6 +60,10 @@ describe('mapToCharacterData', () => {
     currencySpent: 0,
     notes: '',
     consumeReplay: false,
+    overrideXp: false,
+    overrideXpValue: 0,
+    overrideCurrency: false,
+    overrideCurrencyValue: 0,
     ...overrides
   });
 
@@ -372,6 +376,10 @@ describe('mapToCharacterData - Earned Income Calculation', () => {
     currencySpent: 0,
     notes: '',
     consumeReplay: false,
+    overrideXp: false,
+    overrideXpValue: 0,
+    overrideCurrency: false,
+    overrideCurrencyValue: 0,
     ...overrides
   });
 
@@ -759,6 +767,10 @@ describe('Property 6: Data Combination Correctness', () => {
       currencySpent: fc.integer({ min: 0, max: 10000 }),
       notes: fc.string({ maxLength: 500 }),
       consumeReplay: fc.boolean(),
+      overrideXp: fc.boolean(),
+      overrideXpValue: fc.integer({ min: 0, max: 100 }),
+      overrideCurrency: fc.boolean(),
+      overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
     });
 
     fc.assert(
@@ -837,6 +849,10 @@ describe('Property 6: Data Combination Correctness', () => {
       currencySpent: fc.integer({ min: 0, max: 10000 }),
       notes: fc.string({ maxLength: 500 }),
       consumeReplay: fc.boolean(),
+      overrideXp: fc.boolean(),
+      overrideXpValue: fc.integer({ min: 0, max: 100 }),
+      overrideCurrency: fc.boolean(),
+      overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
     });
 
     fc.assert(
@@ -916,7 +932,11 @@ describe('Property 6: Data Combination Correctness', () => {
       earnedIncome: fc.integer({ min: 0, max: 1000 }),
       currencySpent: fc.integer({ min: 0, max: 10000 }),
       notes: fc.constant(''),
-      consumeReplay: fc.boolean()
+      consumeReplay: fc.boolean(),
+      overrideXp: fc.boolean(),
+      overrideXpValue: fc.integer({ min: 0, max: 100 }),
+      overrideCurrency: fc.boolean(),
+      overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true })
     });
 
     fc.assert(
@@ -986,6 +1006,10 @@ describe('Property 6: Data Combination Correctness', () => {
       currencySpent: fc.constant(0),
       notes: fc.string({ maxLength: 500 }),
       consumeReplay: fc.boolean(),
+      overrideXp: fc.boolean(),
+      overrideXpValue: fc.integer({ min: 0, max: 100 }),
+      overrideCurrency: fc.boolean(),
+      overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
     });
 
     fc.assert(
@@ -1050,6 +1074,10 @@ describe('Property 6: Data Combination Correctness', () => {
       currencySpent: fc.integer({ min: 0, max: 10000 }),
       notes: stringArb,
       consumeReplay: fc.boolean(),
+      overrideXp: fc.boolean(),
+      overrideXpValue: fc.integer({ min: 0, max: 100 }),
+      overrideCurrency: fc.boolean(),
+      overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
     });
 
     fc.assert(

--- a/tests/model/party-chronicle-shared-fields.test.ts
+++ b/tests/model/party-chronicle-shared-fields.test.ts
@@ -118,19 +118,22 @@ describe('Party Chronicle Shared Field Property Tests', () => {
             }));
 
             // Property: All characters should have the same shared field values
-            chronicleDataList.forEach(({ chronicleData }) => {
+            chronicleDataList.forEach(({ unique, chronicleData }) => {
               // Verify shared fields are applied to this character
               expect(chronicleData.gmid).toBe(shared.gmPfsNumber);
               expect(chronicleData.event).toBe(shared.scenarioName);
               expect(chronicleData.eventcode).toBe(shared.eventCode);
               expect(chronicleData.date).toBe(shared.eventDate);
-              expect(chronicleData.xp_gained).toBe(shared.xpEarned);
+              // xp_gained uses override when active (gm-override-values 5.1, 5.3)
+              const expectedXp = unique.overrideXp ? unique.overrideXpValue : shared.xpEarned;
+              expect(chronicleData.xp_gained).toBe(expectedXp);
               expect(chronicleData.summary_checkbox).toEqual(shared.adventureSummaryCheckboxes);
               expect(chronicleData.strikeout_item_lines).toEqual(shared.strikeoutItems);
               expect(chronicleData.treasure_bundles).toBe(shared.treasureBundles.toString());
             });
 
             // Property: All characters should have identical shared field values
+            // (xp_gained excluded — it can differ per character when overrides are active)
             if (chronicleDataList.length > 1) {
               const firstChronicle = chronicleDataList[0].chronicleData;
               
@@ -139,7 +142,6 @@ describe('Party Chronicle Shared Field Property Tests', () => {
                 expect(chronicleData.event).toBe(firstChronicle.event);
                 expect(chronicleData.eventcode).toBe(firstChronicle.eventcode);
                 expect(chronicleData.date).toBe(firstChronicle.date);
-                expect(chronicleData.xp_gained).toBe(firstChronicle.xp_gained);
                 expect(chronicleData.summary_checkbox).toEqual(firstChronicle.summary_checkbox);
                 expect(chronicleData.strikeout_item_lines).toEqual(firstChronicle.strikeout_item_lines);
                 expect(chronicleData.treasure_bundles).toBe(firstChronicle.treasure_bundles);
@@ -196,7 +198,6 @@ describe('Party Chronicle Shared Field Property Tests', () => {
               expect(chronicleData.event).toBe(partyShared.scenarioName);
               expect(chronicleData.eventcode).toBe(partyShared.eventCode);
               expect(chronicleData.date).toBe(partyShared.eventDate);
-              expect(chronicleData.xp_gained).toBe(partyShared.xpEarned);
             });
 
             // Property: Outside characters should have outside shared fields (not party fields)
@@ -205,7 +206,6 @@ describe('Party Chronicle Shared Field Property Tests', () => {
               expect(chronicleData.event).toBe(outsideShared.scenarioName);
               expect(chronicleData.eventcode).toBe(outsideShared.eventCode);
               expect(chronicleData.date).toBe(outsideShared.eventDate);
-              expect(chronicleData.xp_gained).toBe(outsideShared.xpEarned);
             });
           }
         ),
@@ -234,7 +234,9 @@ describe('Party Chronicle Shared Field Property Tests', () => {
             expect(chronicleData.event).toBe(shared.scenarioName);
             expect(chronicleData.eventcode).toBe(shared.eventCode);
             expect(chronicleData.date).toBe(shared.eventDate);
-            expect(chronicleData.xp_gained).toBe(shared.xpEarned);
+            // xp_gained uses override when active (gm-override-values 5.1, 5.3)
+            const expectedXp = unique.overrideXp ? unique.overrideXpValue : shared.xpEarned;
+            expect(chronicleData.xp_gained).toBe(expectedXp);
             expect(chronicleData.summary_checkbox).toEqual(shared.adventureSummaryCheckboxes);
             expect(chronicleData.strikeout_item_lines).toEqual(shared.strikeoutItems);
             expect(chronicleData.treasure_bundles).toBe(shared.treasureBundles.toString());
@@ -261,17 +263,20 @@ describe('Party Chronicle Shared Field Property Tests', () => {
             };
 
             // Map all 10 characters
-            const chronicleDataList = characterPairs.map(([_actorId, unique]) =>
-              mapToCharacterData(shared, unique, mockActor)
-            );
+            const chronicleDataList = characterPairs.map(([_actorId, unique]) => ({
+              unique,
+              chronicleData: mapToCharacterData(shared, unique, mockActor)
+            }));
 
             // Property: All 10 characters should have identical shared field values
-            chronicleDataList.forEach(chronicleData => {
+            chronicleDataList.forEach(({ unique, chronicleData }) => {
               expect(chronicleData.gmid).toBe(shared.gmPfsNumber);
               expect(chronicleData.event).toBe(shared.scenarioName);
               expect(chronicleData.eventcode).toBe(shared.eventCode);
               expect(chronicleData.date).toBe(shared.eventDate);
-              expect(chronicleData.xp_gained).toBe(shared.xpEarned);
+              // xp_gained uses override when active (gm-override-values 5.1, 5.3)
+              const expectedXp = unique.overrideXp ? unique.overrideXpValue : shared.xpEarned;
+              expect(chronicleData.xp_gained).toBe(expectedXp);
               expect(chronicleData.summary_checkbox).toEqual(shared.adventureSummaryCheckboxes);
               expect(chronicleData.strikeout_item_lines).toEqual(shared.strikeoutItems);
               expect(chronicleData.treasure_bundles).toBe(shared.treasureBundles.toString());
@@ -308,11 +313,11 @@ describe('Party Chronicle Shared Field Property Tests', () => {
               }
               
               // But shared fields should always be the same
+              // (xp_gained excluded — it can differ per character when overrides are active)
               expect(chronicleData.gmid).toBe(firstChronicle.chronicleData.gmid);
               expect(chronicleData.event).toBe(firstChronicle.chronicleData.event);
               expect(chronicleData.eventcode).toBe(firstChronicle.chronicleData.eventcode);
               expect(chronicleData.date).toBe(firstChronicle.chronicleData.date);
-              expect(chronicleData.xp_gained).toBe(firstChronicle.chronicleData.xp_gained);
               expect(chronicleData.summary_checkbox).toEqual(firstChronicle.chronicleData.summary_checkbox);
               expect(chronicleData.strikeout_item_lines).toEqual(firstChronicle.chronicleData.strikeout_item_lines);
               expect(chronicleData.treasure_bundles).toBe(firstChronicle.chronicleData.treasure_bundles);
@@ -379,12 +384,13 @@ describe('Party Chronicle Shared Field Property Tests', () => {
           ),
           async (shared, characterPairs) => {
             // Map all characters
-            const chronicleDataList = characterPairs.map(([_actorId, unique]) =>
-              mapToCharacterData(shared, unique, mockActor)
-            );
+            const chronicleDataList = characterPairs.map(([_actorId, unique]) => ({
+              unique,
+              chronicleData: mapToCharacterData(shared, unique, mockActor)
+            }));
 
             // Property: All shared field types are correctly propagated
-            chronicleDataList.forEach(chronicleData => {
+            chronicleDataList.forEach(({ unique, chronicleData }) => {
               // String fields
               expect(typeof chronicleData.gmid).toBe('string');
               expect(chronicleData.gmid).toBe(shared.gmPfsNumber);
@@ -403,7 +409,9 @@ describe('Party Chronicle Shared Field Property Tests', () => {
               
               // Number fields
               expect(typeof chronicleData.xp_gained).toBe('number');
-              expect(chronicleData.xp_gained).toBe(shared.xpEarned);
+              // xp_gained uses override when active (gm-override-values 5.1, 5.3)
+              const expectedXp = unique.overrideXp ? unique.overrideXpValue : shared.xpEarned;
+              expect(chronicleData.xp_gained).toBe(expectedXp);
               
               // Array fields
               expect(Array.isArray(chronicleData.summary_checkbox)).toBe(true);

--- a/tests/model/party-chronicle-shared-fields.test.ts
+++ b/tests/model/party-chronicle-shared-fields.test.ts
@@ -70,6 +70,10 @@ const uniqueFieldsArbitrary = fc.record({
   currencySpent: fc.integer({ min: 0, max: 1000 }),
   notes: fc.string({ maxLength: 200 }),
   consumeReplay: fc.boolean(),
+  overrideXp: fc.boolean(),
+  overrideXpValue: fc.integer({ min: 0, max: 100 }),
+  overrideCurrency: fc.boolean(),
+  overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true }),
 });
 
 /**

--- a/tests/model/party-chronicle-storage.test.ts
+++ b/tests/model/party-chronicle-storage.test.ts
@@ -696,7 +696,11 @@ describe('Party Chronicle Storage', () => {
         earnedIncome: fc.float({ min: 0, max: 1000, noNaN: true }),
         currencySpent: fc.integer({ min: 0, max: 10000 }),
         notes: fc.string({ maxLength: 500 }),
-        consumeReplay: fc.boolean()
+        consumeReplay: fc.boolean(),
+        overrideXp: fc.boolean(),
+        overrideXpValue: fc.integer({ min: 0, max: 100 }),
+        overrideCurrency: fc.boolean(),
+        overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true })
       });
 
       const sharedDataArb = fc.record({

--- a/tests/model/party-chronicle-unique-fields.test.ts
+++ b/tests/model/party-chronicle-unique-fields.test.ts
@@ -32,7 +32,11 @@ const uniqueFieldsArbitrary = fc.record({
   earnedIncome: fc.integer({ min: 0, max: 1000 }),
   currencySpent: fc.integer({ min: 0, max: 1000 }),
   notes: fc.string({ maxLength: 200 }),
-  consumeReplay: fc.boolean()
+  consumeReplay: fc.boolean(),
+  overrideXp: fc.boolean(),
+  overrideXpValue: fc.integer({ min: 0, max: 100 }),
+  overrideCurrency: fc.boolean(),
+  overrideCurrencyValue: fc.double({ min: 0, max: 10000, noNaN: true })
 });
 
 /**
@@ -356,7 +360,11 @@ describe('Party Chronicle Unique Field Property Tests', () => {
                 earnedIncome: Math.floor(Math.random() * 100),
                 currencySpent: Math.floor(Math.random() * 1000),
                 notes: `Notes for ${actorId.substring(0, 8)}`,
-                consumeReplay: false
+                consumeReplay: false,
+                overrideXp: false,
+                overrideXpValue: 0,
+                overrideCurrency: false,
+                overrideCurrencyValue: 0
               };
             });
 
@@ -428,7 +436,11 @@ describe('Party Chronicle Unique Field Property Tests', () => {
                 earnedIncome: index * 10,
                 currencySpent: index * 50,
                 notes: `Notes ${index + 1}`,
-                consumeReplay: false
+                consumeReplay: false,
+                overrideXp: false,
+                overrideXpValue: 0,
+                overrideCurrency: false,
+                overrideCurrencyValue: 0
               };
             });
 
@@ -469,7 +481,11 @@ describe('Party Chronicle Unique Field Property Tests', () => {
                 earnedIncome: 10,
                 currencySpent: 20,
                 notes: 'Test notes',
-                consumeReplay: false
+                consumeReplay: false,
+                overrideXp: false,
+                overrideXpValue: 0,
+                overrideCurrency: false,
+                overrideCurrencyValue: 0
               };
             });
 

--- a/tests/model/party-chronicle-unique-fields.test.ts
+++ b/tests/model/party-chronicle-unique-fields.test.ts
@@ -150,7 +150,9 @@ describe('Party Chronicle Unique Field Property Tests', () => {
               
               // Calculate expected gold values
               const expectedTreasureBundlesGp = calculateTreasureBundleValue(shared.treasureBundles, unique.level);
-              const expectedGpGained = calculateCurrencyGained(expectedTreasureBundlesGp, expectedEarnedIncome);
+              const expectedGpGained = unique.overrideCurrency
+                ? unique.overrideCurrencyValue
+                : calculateCurrencyGained(expectedTreasureBundlesGp, expectedEarnedIncome);
               
               // Verify character-specific fields match this character's unique data
               expect(chronicleData.char).toBe(unique.characterName);
@@ -270,7 +272,9 @@ describe('Party Chronicle Unique Field Property Tests', () => {
             
             // Calculate expected gold values
             const expectedTreasureBundlesGp = calculateTreasureBundleValue(shared.treasureBundles, unique.level);
-            const expectedGpGained = calculateCurrencyGained(expectedTreasureBundlesGp, expectedEarnedIncome);
+            const expectedGpGained = unique.overrideCurrency
+              ? unique.overrideCurrencyValue
+              : calculateCurrencyGained(expectedTreasureBundlesGp, expectedEarnedIncome);
 
             // Property: Single character's unique fields are correctly applied
             expect(chronicleData.char).toBe(unique.characterName);

--- a/tests/model/session-report-builder.test.ts
+++ b/tests/model/session-report-builder.test.ts
@@ -310,3 +310,142 @@ describe('buildGameDateTime', () => {
     expect(buildGameDateTime('2026-12-31', new Date('2025-03-15T08:20:00Z'))).toBe('2026-12-31T08:30:00+00:00');
   });
 });
+
+/**
+ * Override-aware session report tests.
+ *
+ * Validates that XP and currency overrides replace calculated values
+ * in the session report when active, and that calculated values are
+ * used when overrides are inactive.
+ *
+ * Requirements: gm-override-values 7.1, 7.2, 7.3
+ */
+describe('Override-aware session report', () => {
+  const partyActor: SessionReportActor = {
+    id: 'p1',
+    name: 'Valeros',
+    system: { pfs: { playerNumber: 11111, characterNumber: 1, currentFaction: 'EA' } },
+  };
+
+  /**
+   * Requirements: gm-override-values 7.1
+   */
+  it('uses override XP when overrideXp is active', () => {
+    const params: SessionReportBuildParams = {
+      shared: createSharedFields({ xpEarned: 4 }),
+      characters: {
+        p1: createUniqueFields({
+          characterName: 'Valeros',
+          overrideXp: true,
+          overrideXpValue: 2,
+          taskLevel: '-',
+        }),
+      },
+      partyActors: [partyActor],
+      layoutId: 'pfs2.s5-18',
+      now: FIXED_NOW,
+    };
+
+    const report = buildSessionReport(params);
+
+    expect(report.signUps[0].xpEarned).toBe(2);
+  });
+
+  /**
+   * Requirements: gm-override-values 7.2
+   */
+  it('uses override currency when overrideCurrency is active', () => {
+    const params: SessionReportBuildParams = {
+      shared: createSharedFields({ treasureBundles: 2, downtimeDays: 4 }),
+      characters: {
+        p1: createUniqueFields({
+          characterName: 'Valeros',
+          overrideCurrency: true,
+          overrideCurrencyValue: 150.5,
+          level: 5,
+          taskLevel: 3,
+          successLevel: 'success',
+          proficiencyRank: 'trained',
+        }),
+      },
+      partyActors: [partyActor],
+      layoutId: 'pfs2.s5-18',
+      now: FIXED_NOW,
+    };
+
+    const report = buildSessionReport(params);
+
+    expect(report.signUps[0].currencyGained).toBe(150.5);
+  });
+
+  /**
+   * Requirements: gm-override-values 7.3
+   */
+  it('uses calculated values when overrides are inactive', () => {
+    const params: SessionReportBuildParams = {
+      shared: createSharedFields({ xpEarned: 4, treasureBundles: 2, downtimeDays: 4 }),
+      characters: {
+        p1: createUniqueFields({
+          characterName: 'Valeros',
+          overrideXp: false,
+          overrideXpValue: 99,
+          overrideCurrency: false,
+          overrideCurrencyValue: 999,
+          level: 5,
+          taskLevel: 3,
+          successLevel: 'success',
+          proficiencyRank: 'trained',
+        }),
+      },
+      partyActors: [partyActor],
+      layoutId: 'pfs2.s5-18',
+      now: FIXED_NOW,
+    };
+
+    const report = buildSessionReport(params);
+
+    expect(report.signUps[0].xpEarned).toBe(4);
+    // Level 5: 2 × 10 = 20 (treasure bundles)
+    // Level 3 trained success: 0.5 gp/day × 4 days = 2 gp (earned income)
+    // Total: 20 + 2 = 22
+    expect(report.signUps[0].currencyGained).toBe(22);
+  });
+
+  /**
+   * Requirements: gm-override-values 7.1, 7.2 — GM character overrides
+   */
+  it('uses override values for GM character in session report', () => {
+    const gmActor: SessionReportActor = {
+      id: 'gm-char-1',
+      name: 'GM Character',
+      system: { pfs: { playerNumber: 54321, characterNumber: 2003, currentFaction: 'GA' } },
+    };
+
+    const params: SessionReportBuildParams = {
+      shared: createSharedFields({ xpEarned: 4, treasureBundles: 2, downtimeDays: 4 }),
+      characters: {
+        p1: createUniqueFields({ characterName: 'Valeros' }),
+      },
+      partyActors: [partyActor],
+      layoutId: 'pfs2.s5-18',
+      now: FIXED_NOW,
+      gmCharacterActor: gmActor,
+      gmCharacterFields: createUniqueFields({
+        characterName: 'GM Character',
+        overrideXp: true,
+        overrideXpValue: 6,
+        overrideCurrency: true,
+        overrideCurrencyValue: 300,
+        level: 10,
+        taskLevel: '-',
+      }),
+    };
+
+    const report = buildSessionReport(params);
+
+    const gmSignUp = report.signUps.find((s) => s.isGM);
+    expect(gmSignUp).toBeDefined();
+    expect(gmSignUp!.xpEarned).toBe(6);
+    expect(gmSignUp!.currencyGained).toBe(300);
+  });
+});

--- a/tests/model/session-report-serializer.property.test.ts
+++ b/tests/model/session-report-serializer.property.test.ts
@@ -57,6 +57,8 @@ const signUpArbitrary: fc.Arbitrary<SignUp> = fc.record({
   consumeReplay: fc.boolean(),
   repEarned: fc.integer({ min: 0, max: 9 }),
   faction: factionNameArbitrary,
+  xpEarned: fc.integer({ min: 0, max: 20 }),
+  currencyGained: fc.double({ min: 0, max: 50000, noNaN: true }),
 });
 
 /** Arbitrary for a single BonusRep entry. */

--- a/tests/model/test-helpers.ts
+++ b/tests/model/test-helpers.ts
@@ -63,6 +63,10 @@ export function createUniqueFields(overrides: Partial<UniqueFields> = {}): Uniqu
     currencySpent: 5,
     notes: 'Test notes',
     consumeReplay: false,
+    overrideXp: false,
+    overrideXpValue: 0,
+    overrideCurrency: false,
+    overrideCurrencyValue: 0,
     ...overrides
   };
 }

--- a/tests/party-chronicle-preservation.property.test.ts
+++ b/tests/party-chronicle-preservation.property.test.ts
@@ -113,7 +113,11 @@ describe('Party Chronicle Form Preservation Tests', () => {
                   earnedIncome: 50,
                   currencySpent: formData.currencySpent,
                   notes: formData.notes,
-                  consumeReplay: false
+                  consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0
                 }
               }
             };
@@ -202,7 +206,11 @@ describe('Party Chronicle Form Preservation Tests', () => {
                   earnedIncome: 50,
                   currencySpent: testData.currencySpent,
                   notes: testData.notes,
-                  consumeReplay: false
+                  consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0
                 }
               }
             };
@@ -245,7 +253,11 @@ describe('Party Chronicle Form Preservation Tests', () => {
                   earnedIncome: 0,
                   currencySpent: 0,
                   notes: '',
-                  consumeReplay: false
+                  consumeReplay: false,
+                  overrideXp: false,
+                  overrideXpValue: 0,
+                  overrideCurrency: false,
+                  overrideCurrencyValue: 0
                 }
               }
             };


### PR DESCRIPTION
## Summary

Add collapsible "Advanced" section to each character card (party members and GM credit) with override controls for XP and currency values. GMs can now override calculated values to account for feats, boons, and downtime activities.

## Changes

- Collapsible "Advanced" section per character card (collapsed by default)
- "Consume Replay" checkbox relocated into the Advanced section
- Override XP checkbox + numeric input
- Override Currency checkbox + numeric input ("Override GP Gained" for Pathfinder, "Override Credits" for Starfinder)
- Checking an override checkbox strikes through the corresponding calculated value and enables the input
- Override values (including zero) replace calculated values in chronicle PDF generation and session reporting
- Override data persists via auto-save and restores on reload
- Per-character scope — overrides are independent across characters

## What was tested

- 1201 unit tests pass (92 test suites)
- ESLint passes with 0 errors
- Manual testing in Foundry VTT for collapsible behavior, strikethrough styling, and override value persistence

## Blocked

- None